### PR TITLE
Add API deprecation notices

### DIFF
--- a/frontend/src/assets/scss/bt/apidocs/_apidocs.scss
+++ b/frontend/src/assets/scss/bt/apidocs/_apidocs.scss
@@ -8,6 +8,17 @@
 
   max-width: 900px;
 
+  .api-notice {
+    margin-top: 50px;
+    background-color: $bt-off-white;
+    color: $bt-indicator-red;
+    padding: 50px;
+    a {
+       color: $bt-indicator-red;
+       font-weight: bold;
+    }
+  }
+
   .swagger-ui div, section.models.is-open h4  {
     font-family: Inter;
   }

--- a/frontend/src/components/Common/Banner.tsx
+++ b/frontend/src/components/Common/Banner.tsx
@@ -11,13 +11,13 @@ import close from '../../assets/svg/common/close.svg'
 interface Props extends PropsFromRedux {}
 
 const Banner: FC<Props> = (props) => {
-  const text = <p>✨ <b>Login</b> to start saving classes and getting Berkeleytime notifications ✨</p>;
+  const text = <p> ⚠️ We will be discontinuing the Berkeleytime API.</p>;
 
   return props.banner ? (
     <div className="banner">
       <div className="content">
         {text}
-        <Button size="sm" href={{as_link: "/releases"}}>Learn More</Button>
+        <Button size="sm" href={{as_link: "/apidocs"}}>Learn More</Button>
       </div>
       <img src={close} alt="close" onClick={props.closeBanner} />
     </div>

--- a/frontend/src/views/Api/Api.jsx
+++ b/frontend/src/views/Api/Api.jsx
@@ -5,6 +5,7 @@ import 'swagger-ui-react/swagger-ui.css';
 function Api() {
   return (
     <div className="apidocs">
+      <div className="api-notice"> Please note that we will be discontinuing the Berkeleytime API. Official support for the API will end on <b> Thursday, April 1st at 11:59PM PST</b>. If you have concerns or would like assistance in removing your dependencies on the Berkeleytime API, please contact us at <a href="mailto:octo.berkeleytime@asuc.org">octo.berkeleytime@asuc.org</a> and we would be more than happy to assist you. </div>
       <SwaggerUI url="/assets/swagger.yaml" docExpansion="list" />
     </div>
   );


### PR DESCRIPTION
Unfortunately, the registrar has told us that publishing an API for other platforms to use (outside of Berkeleytime) is against the terms of service for the APIs we use. In the interest of ensuring that we are compliant and continue to have access to the APIs that we personally use, I think it would be best for us to phase out public access of the API.

![Screen Shot 2021-03-16 at 8 00 14 PM](https://user-images.githubusercontent.com/36020488/111408605-c3027f00-8692-11eb-85c3-629a756bf981.png)
![Screen Shot 2021-03-16 at 8 03 09 PM](https://user-images.githubusercontent.com/36020488/111408609-c433ac00-8692-11eb-9a94-da5c4d069b69.png)
