### PR TITLE
external-access mongodb replica set, miscellaneous redirects to status.berkeleytime.com

### DIFF
--- a/infra/helm/filebeat.yaml
+++ b/infra/helm/filebeat.yaml
@@ -1,10 +1,10 @@
 # Template: https://github.com/elastic/helm-charts/blob/master/filebeat/values.yaml
-# daemonset:
-#   resources:
-#     requests:
+daemonset:
+  resources:
+    requests: {}
 #       cpu: "100m"
 #       memory: "100Mi"
-#     limits:
+    limits: {}
 #       cpu: "100m"
 #       memory: "100Mi"
 filebeatConfig:
@@ -32,53 +32,50 @@ filebeatConfig:
         providers:
           - type: kubernetes
             node: ${NODE_NAME}
-            hints.enabled: true
-            hints.default_config:
-              type: container
-              paths:
-                - /var/log/containers/*${data.kubernetes.container.id}.log
-            templates:
-              # https://gist.github.com/jaganthoutam/34c02a5f19c47a49dcea7b85b9b3667a#file-filebeat-with-pipeline-yaml
-              - condition: # router log formats
-                  or:
-                    - equals:
-                        kubernetes.container.name: controller
-                config:
-                  - type: docker
-                    containers.ids:
-                      - "${data.kubernetes.container.id}"
-                    pipeline: nginx-ingress
-              - condition: # Exclude pods/namespace listed here
-                  or:
-                    - equals:
-                        kubernetes.namespace: kube-system
-                config:
-                  - type: docker
-                    containers.ids:
-                      - "${data.kubernetes.container.id}"
-                    exclude_files: ['.*$']
-              - condition:
-                  or:
-                    - equals:
-                        kubernetes.namespace: default
-                    - equals:
-                        kubernetes.namespace: ingress-nginx
-                config:
-                  - type: docker
-                    containers.ids:
-                      - "${data.kubernetes.container.id}"
-                    exclude_lines: ['healthcheck'] # this is optional
-                    json.message_key: message
-                    json.overwrite_keys: true
-                    json.keys_under_root: true
-                    json.add_error_key: false
-                    json.ignore_decoding_error: true
-                    fields_under_root: true
-                    multiline.pattern: '^{'
-                    multiline.negate: true
-                    multiline.match: after
-                    encoding: utf-8
-                    close_inactive: 5m
+            hints:
+              enabled: true
+              default_config:
+                type: container
+                paths:
+                  - /var/log/containers/*${data.kubernetes.container.id}.log
+            templates: # https://gist.github.com/jaganthoutam/34c02a5f19c47a49dcea7b85b9b3667a#file-filebeat-with-pipeline-yam
+                - condition: # Exclude pods/namespace listed here
+                    or:
+                      - equals:
+                          kubernetes.namespace: kube-system
+                  config:
+                    - type: container
+                      paths:
+                        - /var/log/containers/*${data.kubernetes.container.id}.log
+                      exclude_files: ['.*$']
+                - condition:
+                    or:
+                      - equals:
+                          kubernetes.namespace: default
+                      - equals:
+                          kubernetes.namespace: ingress-nginx
+                  config:
+                    - type: container
+                      paths:
+                        - /var/log/containers/*${data.kubernetes.container.id}.log
+                      exclude_lines: ['healthcheck'] # this is optional
+                      json:
+                        message_key: message
+                        overwrite_keys: true
+                        keys_under_root: true
+                        add_error_key: false
+                        ignore_decoding_error: true
+                      fields_under_root: true
+                      multiline:
+                        pattern: '^{'
+                        negate: true
+                        match: after
+                      encoding: utf-8
+                      close_inactive: 20m
+      queue.mem:
+        events: 4096
+        flush.min_events: 512
+        flush.timeout: 5s
 tolerations:
   - key: node-role.kubernetes.io/master
     operator: Exists

--- a/infra/helm/ingress-nginx.yaml
+++ b/infra/helm/ingress-nginx.yaml
@@ -27,6 +27,6 @@ tcp:
   5432: default/bt-psql-staging:5432::PROXY
   6379: default/bt-redis-staging-master:6379::PROXY
   5433: tutor-staging/postgres:5432::PROXY
-  27017: default/bt-mdb-staging-0:27017
-  27018: default/bt-mdb-staging-1:27017
-  27019: default/bt-mdb-staging-2:27017
+  27017: default/bt-mdb-staging-0:27017::PROXY
+  27018: default/bt-mdb-staging-1:27017::PROXY
+  27019: default/bt-mdb-staging-2:27017::PROXY

--- a/infra/helm/istio-base.yaml
+++ b/infra/helm/istio-base.yaml
@@ -1,4 +1,4 @@
 global:
-  hub: docker.io/istio
-  tag: 1.9-dev.3 # https://hub.docker.com/r/istio/base/tags
+  # hub: docker.io/istio
+  # tag: 1.9-dev.3 # https://hub.docker.com/r/istio/base/tags
   istioNamespace: istio

--- a/infra/helm/istiod.yaml
+++ b/infra/helm/istiod.yaml
@@ -1,6 +1,6 @@
 global:
-  hub: docker.io/istio
-  tag: 1.9.0 # https://hub.docker.com/r/istio/pilot/tags
+  # hub: docker.io/istio
+  # tag: 1.9.0 # https://hub.docker.com/r/istio/pilot/tags
   istioNamespace: istio
   proxy:
     autoInject: disabled

--- a/infra/helm/metricbeat.yaml
+++ b/infra/helm/metricbeat.yaml
@@ -183,30 +183,30 @@ daemonset:
 
 
 
-      - module: postgresql # run 'CREATE extension pg_stat_statements;' in psql
-        enabled: true
-        hosts:
-          - postgres://<USER>:<PASSWORD>@ingress-nginx-controller.ingress-nginx.svc.cluster.local/?sslmode=disable
-        metricsets:
-          - database # Stats about every PostgreSQL database
-          - bgwriter # Stats about the background writer process's activity
-          - activity # Stats about every PostgreSQL process
-          - statement # Stats for statement executions, needs pg_stat_statements
-        period: 10s
+      # - module: postgresql # run 'CREATE extension pg_stat_statements;' in psql
+      #   enabled: true
+      #   hosts:
+      #     - postgres://<username>:<password>@ingress-nginx-controller.ingress-nginx.svc.cluster.local/?sslmode=disable
+      #   metricsets:
+      #     - database # Stats about every PostgreSQL database
+      #     - bgwriter # Stats about the background writer process's activity
+      #     - activity # Stats about every PostgreSQL process
+      #     - statement # Stats for statement executions, needs pg_stat_statements
+      #   period: 10s
 
       # TODO: separate out USER and PASSWORD for postgres and mongodb to secret
 
-      - module: mongodb
-        enabled: true
-        hosts:
-          - mongodb://<USER>:<PASSWORD@berkeleytime.com:27017,berkeleytime.com:27018,berkeleytime.com:27019
-        metricsets:
-          - collstats
-          - dbstats
-          - metrics
-          - replstatus
-          - status
-        period: 10s
+      # - module: mongodb
+      #   enabled: true
+      #   hosts:
+      #     - mongodb://<USER>:<PASSWORD@berkeleytime.com:27017,berkeleytime.com:27018,berkeleytime.com:27019
+      #   metricsets:
+      #     - collstats
+      #     - dbstats
+      #     - metrics
+      #     - replstatus
+      #     - status
+      #   period: 10s
 deployment:
   enabled: false
 livenessProbe:

--- a/infra/helm/mongodb.yaml
+++ b/infra/helm/mongodb.yaml
@@ -13,18 +13,26 @@
 
 # MANUALLY VERIFY WORKS IN MONGO:
 # mongo "mongodb://<username>:<password>@bt-mdb-staging-0.bt-mdb-staging-headless.default.svc.cluster.local,bt-mdb-staging-1.bt-mdb-staging-headless.default.svc.cluster.local/?authSource=admin&replicaSet=rs0"
+# OR for external access:
+# mongo "mongodb+srv://<username>:<password>@mdb.berkeleytime.com/?authSource=admin&replicaSet=rs0"
 # use bt
-# db.asdf.insertOne({ name: "Mango", season: "Summer"})
-# db.asdf.find({})
+# db.fruits.insertOne({ name: "Mango", season: "Summer"})
+# db.fruits.find({})
 
 # example secret format for existingSecret:
 # mongodb-password=<any pass>
 # mongodb-replica-set-key=<any key>
 # mongodb-root-password=<any pass>
 
+# Fancy mongodb dns srv records in GCP so that mongodb+srv is possible
+# gcloud dns record-sets delete --zone berkeleytime --type SRV _mongodb._tcp.mdb.berkeleytime.com.
+# gcloud dns record-sets delete --zone berkeleytime --type TXT mdb.berkeleytime.com.
+# gcloud dns record-sets create _mongodb._tcp.mdb.berkeleytime.com. --type SRV --ttl 300 --zone berkeleytime --rrdatas "0 0 27017 mdb0.berkeleytime.com.","0 0 27018 mdb1.berkeleytime.com.","0 0 27019 mdb2.berkeleytime.com."
+# gcloud dns record-sets create mdb.berkeleytime.com. --type TXT --ttl 300 --zone berkeleytime --rrdatas "authSource=bt&replicaSet=rs0"
+
 arbiter:
   enabled: false
-architecture: replicaset
+architecture: replicaset # replicaset is great as it enables transaction support
 auth:
   enabled: true
   existingSecret: bt-mdb-$CI_ENVIRONMENT_NAME
@@ -47,15 +55,86 @@ externalAccess:
 readinessProbe: # must be disabled so that traffic can go through svc for init
   enabled: false
 replicaCount: 3
-# TODO: Must automate sending this command for staging external cluster access
-# rs.reconfig({
-#    _id : "rs0",
-#    members: [
-#       { _id: 0, host: "berkeleytime.com:27017" },
-#       { _id: 1, host: "berkeleytime.com:27018" },
-#       { _id: 2, host: "berkeleytime.com:27019" }
-#    ]
-# }, { force: true })
+sidecars: # This sidecar waits first time replica set start, then change to dns
+  - name: mongo
+    image: mongo:4.4.4
+    env:
+      - name: DOMAIN
+        value: berkeleytime.com
+      - name: PORT
+        value: "27017"
+      - name: REPLICAS
+        value: "3"
+    envFrom:
+      - secretRef:
+          name: bt-mdb-$CI_ENVIRONMENT_NAME
+    command:
+      - bash
+      - -c
+      - |
+        while true
+        do
+          password=`env | sed -n 's/mongodb-root-password=\(.*\)/\1/p'`
+
+          mongo "mongodb://root:${password}@localhost" << EOF
+            const replicaCount = $REPLICAS;
+            const domain = "$DOMAIN";
+            const h = getHostName();
+            const baseHostname = h.split('-').slice(0, -1).join('-');
+            const basePort = $PORT;
+            const c = rs.conf();
+            const s = rs.status();
+
+            if (s.members.every(member => member.name.includes(baseHostname) && member.health == 1) ||
+                s.members.every(member => member.name.includes(domain) && member.health == 1) ) {
+                if (s.members.length == replicaCount) {
+                  print("all replicas healthy and properly named");
+                  quit(255);
+                } else {
+                  print("some replicas are missing");
+                  quit(0);
+                }
+            }
+
+            for (let [index, value] of c.members.entries()) {
+              let port;
+              if (h.includes('staging')) {
+                c.members[index].host = \`$DOMAIN:\${basePort + index}\`;
+              } else {
+                c.members[index].host = \`\${baseHostname}-\${index}:\${basePort}\`;
+              }
+            }
+            rs.reconfig(c, { force: true });
+        EOF
+
+          if [[ $? -eq 255 ]]; then
+            echo ...`date +"%Y-%m-%d %H:%M:%S"` replica set is configured correctly...
+            sleep 600
+          else
+            echo "retrying replica set configuration..."
+            sleep 15
+          fi
+        done
+# tls:
+#   enabled: true
+#   caCert: $CA_CERT
+#   caKey: $CA_KEY
+
+# old bash tricks but helpful tricks to keep just in case
+# function check(){
+#   mongo --eval 'db.runCommand("ping").ok' mongodb://root:${password}@$1 --quiet
+# }
+# i=$((${#HOSTNAME}-1))
+# if [[ "${HOSTNAME:$i:1}" =~ "0" ]]
+# then
+#   # this is member 0, attempt to initialize replica set
+# EOF
+# else
+#   echo this node is not the first init member, do nothing
+#   while true; do sleep 1000; done;
+# fi
+
+# can replace container cmd, perhaps automate for staging external access
 # command:
 #   - bash
 #   - -c

--- a/infra/k8s/default/bt-gitlab.yaml
+++ b/infra/k8s/default/bt-gitlab.yaml
@@ -116,7 +116,7 @@ spec:
               mkdir -p /var/opt/gitlab/git-data/repositories
       containers:
         - name: bt-gitlab
-          image: gitlab/gitlab-ee:13.7.5-ee.0
+          image: gitlab/gitlab-ee:13.10.3-ee.0
           lifecycle:
             preStop:
               exec:

--- a/infra/k8s/default/bt-ingress-infra.yaml
+++ b/infra/k8s/default/bt-ingress-infra.yaml
@@ -8,67 +8,58 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: bt-ingress-infra-$INGRESS_LABEL-public
   annotations:
-    kubernetes.io/ingress.class: nginx
     cert-manager.k8s.io/cluster-issuer: letsencrypt
-    nginx.ingress.kubernetes.io/use-regex: "true"
-    nginx.ingress.kubernetes.io/from-to-www-redirect: "true"
-    nginx.ingress.kubernetes.io/server-snippet: |-
-      server_name $BASE_DOMAIN_NAME ~^www\.;
-      if ($host ~* www\.(.*)) {
-        set $host_without_www $1;
-        rewrite ^(.*)$ $scheme://$host_without_www$1 permanent;
-      }
+    kubernetes.io/ingress.class: nginx
+  name: bt-ingress-infra-$INGRESS_LABEL-public
 spec:
-  tls:
-    - hosts:
-        - berkeleytime.com
-        - "*.berkeleytime.com"
-      secretName: bt-tls
   rules:
     - host: $BASE_DOMAIN_NAME
       http:
         paths:
-          - path: /git
-            pathType: Prefix
-            backend:
+          - backend:
               service:
                 name: bt-gitlab
                 port:
                   number: 80
-          - path: /webhooks/github
+            path: /git
             pathType: Prefix
-            backend:
+          - backend:
               service:
                 name: bt-github-notify
                 port:
                   number: 80
-
+            path: /webhooks/github
+            pathType: Prefix
+  tls:
+    - hosts:
+        - berkeleytime.com
+        - '*.berkeleytime.com'
+      secretName: bt-tls
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: bt-ingress-infra-$INGRESS_LABEL-protected-routes
   annotations:
-    kubernetes.io/ingress.class: nginx
     cert-manager.k8s.io/cluster-issuer: letsencrypt
-    nginx.ingress.kubernetes.io/auth-type: basic
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/auth-realm: Authentication Required - Login with credentials
     nginx.ingress.kubernetes.io/auth-secret: bt-ingress-protected-routes
-    nginx.ingress.kubernetes.io/auth-realm: "Authentication Required - Login with credentials"
+    nginx.ingress.kubernetes.io/auth-type: basic
+  name: bt-ingress-infra-$INGRESS_LABEL-protected-routes
 spec:
-  tls:
-    - hosts:
-        - berkeleytime.com
-      secretName: bt-tls
   rules:
     - host: $BASE_DOMAIN_NAME
       http:
         paths:
-          - path: /kibana
-            pathType: Prefix
-            backend:
+          - backend:
               service:
                 name: bt-kibana-kibana
                 port:
                   number: 5601
+            path: /kibana
+            pathType: Prefix
+  tls:
+    - hosts:
+        - berkeleytime.com
+      secretName: bt-tls

--- a/infra/k8s/default/bt-ingress-primary.yaml
+++ b/infra/k8s/default/bt-ingress-primary.yaml
@@ -16,6 +16,14 @@ metadata:
     nginx.ingress.kubernetes.io/use-regex: "true"
     nginx.ingress.kubernetes.io/from-to-www-redirect: "true"
     nginx.ingress.kubernetes.io/server-snippet: |-
+      proxy_intercept_errors on;
+      error_page 404 500 501 502 503 504 = @errorpages;
+      
+      location @errorpages {
+        proxy_set_header X-Code $status;
+        proxy_pass http://bt-status-primary.default.svc.cluster.local;
+      }
+
       server_name $BASE_DOMAIN_NAME ~^www\.;
       if ($host ~* www\.(.*)) {
         set $host_without_www $1;

--- a/infra/k8s/default/bt-ingress-status.yaml
+++ b/infra/k8s/default/bt-ingress-status.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: bt-status-$INGRESS_LABEL
+spec:
+  defaultBackend:
+    service:
+      name: bt-status-$INGRESS_LABEL
+      port:
+        number: 80
+  tls:
+    - hosts:
+        - berkeleytime.com
+        - '*.berkeleytime.com'
+      secretName: bt-tls
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: bt-status-$INGRESS_LABEL
+spec:
+  externalName: status.berkeleytime.com
+  ports:
+    - port: 80
+      protocol: TCP
+      targetPort: 443
+  type: ExternalName

--- a/infra/k8s/default/certificate.yaml
+++ b/infra/k8s/default/certificate.yaml
@@ -11,6 +11,7 @@ spec:
   dnsNames:
     - berkeleytime.com
     - "*.berkeleytime.com"
-    - "*.staging.berkeleytime.com"
     - "*.ocf.berkeleytime.com"
+    - "*.staging.berkeleytime.com"
     - "*.staging.ocf.berkeleytime.com"
+    - "*.status.berkeleytime.com"


### PR DESCRIPTION
1. externally accessible bt-mdb-staging; seems stable for now, example CLI: `mongo "mongodb+srv://<username>:<password>@mdb.berkeleytime.com/bt?ssl=false"`

2. redirect to status.berkeleytime.com from asdf.berkeleytime.com currently already working, but this PR makes berkeleytime.com redirect to try to status.berkeleytime.com if frontend prod pod fails to respond. seems to work

https://user-images.githubusercontent.com/48421163/115357128-28093300-a171-11eb-8c36-5f33004cbb8b.mp4

3. miscellaneous version updates to various stuff

TO-DO:
- enable SSL on mdb-staging, otherwise "?ssl=false" mandatory since "mongodb+srv" DNS trick SSL to be default for connecting clients