### PR TITLE
Add fall 2022 class config

### DIFF
--- a/backend/berkeleytime/config/finals/semesters/fall2022.py
+++ b/backend/berkeleytime/config/finals/semesters/fall2022.py
@@ -1,0 +1,56 @@
+from berkeleytime.config.finals.finals import *
+from berkeleytime.config.finals.finals_general import FINAL_TIMES
+
+# CHANGE THESE DICTIONARIES SEMESTER TO SEMESTER AND TRIPLE CHECK THAT THEY ARE RIGHT
+# Source: https://registrar.berkeley.edu/scheduling/academic-scheduling/final-exam-guide-schedules
+
+MWF_FINALS = {
+    datetime.time(8, 0): FINAL_TIMES["Monday7-10PM"],
+    datetime.time(9, 0): FINAL_TIMES["Thursday7-10PM"],
+    datetime.time(10, 0): FINAL_TIMES["Monday8-11AM"],
+    datetime.time(11, 0): FINAL_TIMES["Monday11:30-2:30PM"],
+    datetime.time(12, 0): FINAL_TIMES["Thursday11:30-2:30PM"],
+    datetime.time(13, 0): FINAL_TIMES["Wednesday7-10PM"],
+    datetime.time(14, 0): FINAL_TIMES["Thursday3-6PM"],
+    datetime.time(15, 0): FINAL_TIMES["Tuesday7-10PM"],
+    datetime.time(16, 0): FINAL_TIMES["Thursday8-11AM"],
+    datetime.time(17, 0): FINAL_TIMES["Friday3-6PM"]
+}
+
+TR_FINALS = {
+    datetime.time(8, 0): FINAL_TIMES["Wednesday3-6PM"],
+    datetime.time(9, 0): FINAL_TIMES["Tuesday3-6PM"],
+    datetime.time(10, 0): FINAL_TIMES["Friday3-6PM"],
+    datetime.time(11, 0): FINAL_TIMES["Wednesday8-11AM"],
+    datetime.time(12, 0): FINAL_TIMES["Friday8-11AM"],
+    datetime.time(13, 0): FINAL_TIMES["Friday8-11AM"],
+    datetime.time(14, 0): FINAL_TIMES["Tuesday8-11AM"],
+    datetime.time(15, 0): FINAL_TIMES["Friday7-10PM"],
+    datetime.time(16, 0): FINAL_TIMES["Friday7-10PM"],
+    datetime.time(17, 0): FINAL_TIMES["Thursday11:30-2:30PM"]
+}
+
+HARD_CODED = [
+    ("ECON", ['1', '100B'], FINAL_TIMES.get("Tuesday11:30-2:30PM")),
+    ("UGBA", ["101B"], FINAL_TIMES.get("Tuesday11:30-2:30PM")),
+    ("CHEM", ["1A", "1B", "3A", "3B", "4A", "4B"], FINAL_TIMES.get("Monday3-6PM")),
+    ("ECON", ["140"], FINAL_TIMES.get("Monday3-6PM")),
+    ("ENGLISH", ['1A', '1B', 'R1A', 'R1B'], FINAL_TIMES.get("Friday3-6PM")),
+]
+
+# Mapper function for final times
+def fall_2022_finals_logic(abbreviation, course_number, start_time, is_foreign_language, day_string):
+    for dept, numbers, time in HARD_CODED:
+        if dept == abbreviation and course_number in numbers:
+            return time
+    if is_foreign_language or course_number[0] == "W":
+        return FINAL_TIMES.get("Wednesday11:30-2:30PM")
+    elif day_string == MWF:
+        return MWF_FINALS.get(start_time)
+    elif day_string == TR:
+        return TR_FINALS.get(start_time)
+    elif is_weekend_class(day_string):
+        return FINAL_TIMES.get("Wednesday3-6PM")
+    return None
+
+finals_mapper = FinalTimesMapper(fall_2022_finals_logic)

--- a/backend/berkeleytime/config/general.py
+++ b/backend/berkeleytime/config/general.py
@@ -19,6 +19,7 @@ from berkeleytime.config.semesters import (
     spring2021,
     fall2021,
     spring2022,
+    fall2022,
 )
 
 GRADE_POINT = {
@@ -56,6 +57,7 @@ PAST_SEMESTERS = [
     {'semester': 'fall', 'year': '2020', 'display': 'Fall 2020'},
     {'semester': 'spring', 'year': '2021', 'display': 'Spring 2021'},
     {'semester': 'fall', 'year': '2021', 'display': 'Fall 2021'},
+    {'semester': 'spring', 'year': '2022', 'display': 'Spring 2022'},
 ]
 
 PAST_SEMESTERS_SIS = [
@@ -70,6 +72,7 @@ PAST_SEMESTERS_SIS = [
     {'semester': 'fall', 'year': '2020', 'display': 'Fall 2020'},
     {'semester': 'spring', 'year': '2021', 'display': 'Spring 2021'},
     {'semester': 'fall', 'year': '2021', 'display': 'Fall 2021'},
+    {'semester': 'spring', 'year': '2022', 'display': 'Spring 2022'},
 ]
 
 
@@ -95,6 +98,7 @@ PAST_SEMESTERS_TELEBEARS_JSON = {
     'spring 2021': spring2021.TELEBEARS_JSON,
     'fall 2021': fall2021.TELEBEARS_JSON,
     'spring 2022': spring2022.TELEBEARS_JSON,
+    'fall 2022': fall2022.TELEBEARS_JSON,
 }
 
 PAST_SEMESTERS_TELEBEARS = {
@@ -117,6 +121,7 @@ PAST_SEMESTERS_TELEBEARS = {
     'spring 2021': spring2021.TELEBEARS,
     'fall 2021': fall2021.TELEBEARS,
     'spring 2022': spring2022.TELEBEARS,
+    'fall 2022': fall2022.TELEBEARS_JSON,
 }
 
 # Classes with special characters

--- a/backend/berkeleytime/config/semesters/fall2022.py
+++ b/backend/berkeleytime/config/semesters/fall2022.py
@@ -1,0 +1,42 @@
+"""Configurations for Fall 2022."""
+from berkeleytime.config.finals.semesters.fall2022 import *
+
+import datetime
+
+CURRENT_SEMESTER = 'fall'
+CURRENT_YEAR = '2022'
+CURRENT_SEMESTER_DISPLAY = 'Fall 2022'
+
+# SIS API Keys
+SIS_TERM_ID = 2228
+
+TELEBEARS = {
+    'phase1_start': datetime.datetime(2022, 4, 18),
+    'phase1_end': datetime.datetime(2022, 6, 17),
+    'phase2_start': datetime.datetime(2022, 7, 18),
+    'phase2_end': datetime.datetime(2022, 8, 14),
+
+    'adj_start': datetime.datetime(2022, 8, 15),
+}
+
+INSTRUCTION = {
+    'instruction_start': datetime.datetime(2022, 8, 24, 00, 00),
+    'instruction_end': datetime.datetime(2022, 12, 9, 00, 00)
+}
+
+# Please don't edit anything below this line unless you know what you are doing
+
+TELEBEARS_JSON = {
+    'phase1_start_date': TELEBEARS['phase1_start'].strftime('%m/%d/%Y-%H:%M:%S'),
+    'phase1_end_date': TELEBEARS['phase1_end'].strftime('%m/%d/%Y-%H:%M:%S'),
+    'phase1_start_day': 1,
+    'phase1_end_date': (TELEBEARS['phase1_end'] - TELEBEARS['phase1_start']).days + 1,
+    'phase2_start_date': TELEBEARS['phase2_start'].strftime('%m/%d/%Y-%H:%M:%S'),
+    'phase2_end_date': TELEBEARS['phase2_end'].strftime('%m/%d/%Y-%H:%M:%S'),
+    'phase2_start_day': (TELEBEARS['phase2_start'] - TELEBEARS['phase1_start']).days + 1,
+    'phase2_end_date': (TELEBEARS['phase2_end'] - TELEBEARS['phase1_start']).days + 1,
+    'adj_start_date': TELEBEARS['adj_start'].strftime('%m/%d/%Y-%H:%M:%S'),
+    'adj_start_day': (TELEBEARS['adj_start'] - TELEBEARS['phase1_start']).days + 1,
+}
+
+TELEBEARS_ALREADY_STARTED = datetime.datetime.now() >= TELEBEARS['phase1_start']

--- a/backend/berkeleytime/settings.py
+++ b/backend/berkeleytime/settings.py
@@ -19,7 +19,7 @@ from datetime import timedelta
 from urllib.parse import urlparse
 
 from berkeleytime.config.general import *
-from berkeleytime.config.semesters.spring2022 import *
+from berkeleytime.config.semesters.fall2022 import *
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent


### PR DESCRIPTION
It's that time again!

Follows [this](https://github.com/asuc-octo/berkeleytime/wiki/New-Semester-Runbook) guide.
Spring 2022 enrollment date information pulled from [here](https://chemistry.berkeley.edu/ugrad/current-students/important-dates).
Final exam group datetimes from [here](https://registrar.berkeley.edu/scheduling/academic-scheduling/academic-scheduling-final-exam-guide-and-schedules/).

Generally the same as #472 but for Fall 2022.