### PR TITLE
Fix backend L&S breadth parser endpoint URL

### DIFF
--- a/backend/playlist/resource/ls.py
+++ b/backend/playlist/resource/ls.py
@@ -37,7 +37,7 @@ class LSResource(object):
         PAST_SEMESTERS_SIS + [{'semester': CURRENT_SEMESTER, 'year': CURRENT_YEAR}]
     )
     # Max page size is 100. We only want courses that are marked as active.
-    url = 'https://apis.berkeley.edu/sis/v1/classes/sections?term-id=%s&page-number=%s&page-size=100&status-code=A'
+    url = 'https://apis.berkeley.edu/uat/sis/v1/classes/sections?term-id=%s&page-number=%s&page-size=100&status-code=A'
     headers = {
         'accept': 'application/json',
         'app_id': SIS_CLASS_APP_ID,


### PR DESCRIPTION
See #490, specifically this portion [here](https://github.com/asuc-octo/berkeleytime/issues/490#issuecomment-1101755470). Does not fix the static playlist selection issue.