### PR TITLE
Disable recruitment banner

### DIFF
--- a/frontend/src/Berkeleytime.tsx
+++ b/frontend/src/Berkeleytime.tsx
@@ -61,19 +61,19 @@ class Berkeleytime extends Component<Props> {
   constructor(props: Props) {
     super(props)
 
-    const bannerType = 'fa22recruitment'  // should match value in ./redux/common/reducer.ts
-    if (localStorage.getItem('bt-hide-banner') !== bannerType) {
-      props.openBanner()
-    }
+    // const bannerType = 'fa22recruitment'  // should match value in ./redux/common/reducer.ts
+    // if (localStorage.getItem('bt-hide-banner') !== bannerType) {
+    //   props.openBanner()
+    // }
 
     const modalType = 'sp22scheduler'  // should match value in ./redux/common/reducer.ts
     if (localStorage.getItem('bt-hide-landing-modal') !== modalType) {
       props.openLandingModal()
     }
 
-    
+
     easterEgg()
-    
+
     const key = 'bt-spring-2021-catalog'
     if (localStorage.getItem(key) === null) {
       localStorage.setItem(key, key)


### PR DESCRIPTION
Comment out code that enables the recruitment banner. Commented out instead of deleted so that we can easily restore it for the next recruitment cycle.