### PR TITLE
feat: postgres docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ config.statuspage.json
 *.key
 db/
 mdb.archive
+bt_seed.sql
+bt_seed.sql.gz

--- a/Makefile
+++ b/Makefile
@@ -19,3 +19,6 @@ frontend:
 
 backend:
 	docker-compose -f build/docker-compose.yml up backend redis nginx
+
+postgres: 
+	docker-compose -f build/docker-compose.yml up postgres

--- a/build/docker-compose.yml
+++ b/build/docker-compose.yml
@@ -3,6 +3,8 @@ services:
   backend:
     build:
       context: ../backend
+    depends_on:
+      - postgres
     command:
         - /bin/bash
         - -c
@@ -36,12 +38,12 @@ services:
      - frontend
   postgres:
     container_name: bt_postgres
-    image: postgres:latest
+    image: postgres:12.6
     volumes:
       - ./bt_main.dump:/bt_main.dump
       - ./postgres-data:/var/lib/postgresql/data
     ports:
-      - "54321:5432"
+      - "5432:5432"
     environment:
       - "POSTGRES_DB=bt_main"
       - "POSTGRES_USER=bt"

--- a/build/docker-compose.yml
+++ b/build/docker-compose.yml
@@ -34,3 +34,16 @@ services:
     depends_on:
      - backend
      - frontend
+  postgres:
+    container_name: bt_postgres
+    image: postgres:latest
+    volumes:
+      - ./bt_main.dump:/bt_main.dump
+      - ./postgres-data:/var/lib/postgresql/data
+    ports:
+      - "54321:5432"
+    environment:
+      - "POSTGRES_DB=bt_main"
+      - "POSTGRES_USER=bt"
+      - "POSTGRES_PASSWORD=bt"
+ 

--- a/build/docker-compose.yml
+++ b/build/docker-compose.yml
@@ -41,7 +41,7 @@ services:
     image: postgres:12.6
     volumes:
       - ./bt_main.dump:/bt_main.dump
-      - ./postgres-data:/var/lib/postgresql/data
+      - postgres-data:/var/lib/postgresql/data
     ports:
       - "5432:5432"
     environment:
@@ -49,3 +49,7 @@ services:
       - "POSTGRES_USER=bt"
       - "POSTGRES_PASSWORD=bt"
  
+volumes:
+  postgres-data:
+ 
+ # docker-compose up --build backend

--- a/setup.md
+++ b/setup.md
@@ -8,10 +8,17 @@ Docker is a container platform and Docker Compose is a a tool for defining and r
 Docker applications. Make sure you have both install on your computer before you start. Docker Compose
 comes with Docker in most cases (such as MacOS).
 
-To run Berkeleytime, make sure this repo is clone. From the top level, first download the development
-Postgres data with `make init`. This will create a folder `build/postgres-data`. Don't try to push it to Github - 
-its a local copy of the production data. Note: If you recieve the error `make: wget: No such file or directory`, make sure you have `wget` installed.
+### Seeding the Local Database
+To run Berkeleytime, make sure this repo is cloned. From the top level, first download the development
+Postgres data:
+1. `make postgres` - start up the postgres container
+2. `curl -O https://storage.googleapis.com/berkeleytime/public/bt_seed.sql.gz` - download the database as a GZip file
+3. `gzip -d bt_seed.sql.gz` - unzip this file
+4. `cat bt_seed.sql | docker exec -i bt_postgres psql -U bt -d bt_main` - see Postgres container with the data.
 
+Before starting the server, make sure the `DATABASE_URL` entry in your `.env.dev` is `postgres://bt:bt@postgres:5432/bt_main` so that the backend connects to the local DB.
+
+### Starting the local server
 To boot the services, run `make up`. This will boot 6 containers (redis, postgres, nginx, Django, Node.js). Wait for both
 Postgres and Django to be running before you proceed. Django will say 
 


### PR DESCRIPTION
Added postgres docker container in `docker-compose` and seed data to gcp bucket. 

### To run the docker container
`make postgres`

## To seed the database: 
### Download data and unzip 
`curl -O https://storage.googleapis.com/berkeleytime/public/bt_seed.sql.gz`
`gzip -d bt_seed.sql.gz`

### Seed postgres running on docker 
`cat bt_seed.sql | docker exec -i bt_postgres psql -U bt -d bt_main`

### Seeding 
- Kept only 2020 data 
- Removed all foreign key constraints for saving space and deletion time
- Seeding takes ~5 minutes
  - This is mainly blocked by the table `enrollment`, which I can't filter because it doesn't have a timestamp. 

### Revision: 
- Pin postgres version to `12.6`
- Change port to `5432`
- Backend container depends on postgres container 
