### PR TITLE
Update modal overflow

### DIFF
--- a/frontend/src/assets/scss/bt/catalog/_modal.scss
+++ b/frontend/src/assets/scss/bt/catalog/_modal.scss
@@ -28,7 +28,7 @@
     .modal-content {
       border: 0px;
       border-radius: 0px;
-      overflow: scroll;
+      overflow: hidden;
 
       svg {
         margin-right: 8px;

--- a/frontend/src/assets/scss/bt/landing/_landing_modal.scss
+++ b/frontend/src/assets/scss/bt/landing/_landing_modal.scss
@@ -65,6 +65,7 @@
       padding: 50px !important;
       text-align: center !important;
       border-radius: 4px !important;
+      overflow: hidden;
     }
   }
 }


### PR DESCRIPTION
Changed overflow from `scroll` to `hidden` in order to hide scroll bars on some devices.