### PR TITLE
Improve appearance of grades graph on mobile

### DIFF
--- a/alumni.txt
+++ b/alumni.txt
@@ -1,1 +1,0 @@
-hiroshi '22 danji '22 vihan '24 annie '23 shuming '24

--- a/alumni.txt
+++ b/alumni.txt
@@ -1,0 +1,1 @@
+hiroshi '22 danji '22 vihan '24 annie '23 shuming '24

--- a/frontend/src/assets/scss/bt/grades/_grades.scss
+++ b/frontend/src/assets/scss/bt/grades/_grades.scss
@@ -25,7 +25,7 @@
   }
 
   .btn-primary:disabled {
-      cursor: default;
+    cursor: default;
   }
 
   .css-yk16xz-control:hover {
@@ -100,15 +100,15 @@
   box-shadow: none;
   border: none;
 
-    .graph-content {
-      .graph {
-        padding: 15px 15px 15px 15px;
-      }
-      .graph-title {
-          font-weight: bold;
-          font-size: 20px;
-      }
+  .graph-content {
+    .graph {
+      padding: 15px 15px 15px 15px;
     }
+    .graph-title {
+      font-weight: bold;
+      font-size: 20px;
+    }
+  }
 }
 
 // GradesInfoCard
@@ -116,47 +116,47 @@
   box-shadow: none;
 
   .content {
-      padding: 0px 15px 15px 15px;
+    padding: 0px 15px 15px 15px;
 
-      .class-num {
+    .class-num {
+      font-weight: bold;
+      font-size: 20px;
+      width: fit-content;
+    }
+
+    .class-info {
+      margin-top: 5px;
+      color: #8F8F8F;
+    }
+
+    .class-title {
+      padding-top: 5px;
+      padding-bottom: 10px;
+    }
+
+    .class-avgs {
+      padding: 0;
+
+      .class-avg-stats {
+        padding: 0;
+        font-size: 15px;
         font-weight: bold;
-        font-size: 20px;
-        width: fit-content;
+        margin-bottom: 3%;
       }
 
-      .class-info {
-        margin-top: 5px;
+      .class-stats-name {
         color: #8F8F8F;
       }
 
-      .class-title {
-        padding-top: 5px;
-        padding-bottom: 10px;
+      .class-grade {
+        font-size: 18px;
+        font-weight: bold;
       }
 
-      .class-avgs {
-        padding: 0;
-
-        .class-avg-stats {
-          padding: 0;
-          font-size: 15px;
-          font-weight: bold;
-          margin-bottom: 3%;
-        }
-
-        .class-stats-name {
-          color: #8F8F8F;
-        }
-
-        .class-grade {
-          font-size: 18px;
-          font-weight: bold;
-        }
-
-        .class-percent {
-          color:gray;
-          font-size: 18px;
-        }
+      .class-percent {
+        color:gray;
+        font-size: 18px;
       }
+    }
   }
 }

--- a/frontend/src/assets/scss/bt/grades/_grades.scss
+++ b/frontend/src/assets/scss/bt/grades/_grades.scss
@@ -11,7 +11,7 @@
   }
 
   .grades-mobile-heading {
-    margin: 30px 0px 30px 10px;
+    margin: 10px 0px 5px 10px;
     font-size: 20px;
     font-weight: 500;
   }

--- a/frontend/src/assets/scss/bt/grades/_graph.scss
+++ b/frontend/src/assets/scss/bt/grades/_graph.scss
@@ -1,32 +1,33 @@
 .grades-graph {
-	margin-top: 20px;
-	max-width: 90vw;
+  margin-top: 20px;
+  max-width: 90vw;
 
-		g.recharts-layer.recharts-cartesian-axis.recharts-xAxis.xAxis, g.recharts-layer.recharts-cartesian-axis.recharts-yAxis.yAxis {
-			opacity: .5;
-		}
+  g.recharts-layer.recharts-cartesian-axis.recharts-xAxis.xAxis,
+  g.recharts-layer.recharts-cartesian-axis.recharts-yAxis.yAxis {
+    opacity: 0.5;
+  }
 
-		.recharts-surface {
-	    @include desktop {
-				height: 410px;
-			}
-	  }
+  .recharts-surface {
+    @include desktop {
+      height: 410px;
+    }
+  }
 
-		.recharts-default-tooltip {
-	    border-radius: 4px;
-	    border: 1px solid rgb(225, 225, 225);
-	}
+  .recharts-default-tooltip {
+    border-radius: 4px;
+    border: 1px solid rgb(225, 225, 225);
+  }
 
-  	.grades-graph-tooltip {
-			opacity: 1 !important;
-  		background: white;
-  		outline: 2px solid $bt-border-grey;
-  		text-align: left;
-  		padding: 12px 12px 12px 12px;
+  .grades-graph-tooltip {
+    opacity: 1 !important;
+    background: white;
+    outline: 2px solid $bt-border-grey;
+    text-align: left;
+    padding: 12px 12px 12px 12px;
 
-  		h6 {
-  			margin-bottom: 5px;
-      		font-weight: bold;
-  		}
-  	}
+    h6 {
+      margin-bottom: 5px;
+      font-weight: bold;
+    }
+  }
 }

--- a/frontend/src/assets/scss/bt/grades/_graph.scss
+++ b/frontend/src/assets/scss/bt/grades/_graph.scss
@@ -11,9 +11,11 @@
     @include desktop {
       height: 410px;
     }
+    // don't cut off number label on widest bar in mobile view
+    overflow: visible;
   }
 
-  .recharts-default-tooltip {
+  .recharts-default-tooltip, .grades-graph-tooltip {
     border-radius: 4px;
     border: 1px solid rgb(225, 225, 225);
   }
@@ -21,7 +23,6 @@
   .grades-graph-tooltip {
     opacity: 1 !important;
     background: white;
-    outline: 2px solid $bt-border-grey;
     text-align: left;
     padding: 12px 12px 12px 12px;
 

--- a/frontend/src/components/ClassCards/ClassCardMobile.jsx
+++ b/frontend/src/components/ClassCards/ClassCardMobile.jsx
@@ -26,7 +26,7 @@ function ClassCardMobile(props) {
           {nullCheck(courseLetter) ?
             <div className="bt-h6">
               <span className={getGradeColor(courseLetter)}>{courseLetter}</span>
-              (GPA: {courseGPA})
+              {' '}(GPA: {courseGPA})
             </div>
           :
           "--"}
@@ -36,7 +36,7 @@ function ClassCardMobile(props) {
           {nullCheck(sectionLetter) ?
             <div className="bt-h6">
               <span className={getGradeColor(sectionLetter)}>{sectionLetter}</span>
-              (GPA: {sectionGPA})
+              {' '}(GPA: {sectionGPA})
             </div>
             :
             "--"}

--- a/frontend/src/components/Graphs/GradesGraph.jsx
+++ b/frontend/src/components/Graphs/GradesGraph.jsx
@@ -8,14 +8,12 @@ import {
   Legend,
   ResponsiveContainer,
 } from 'recharts';
-import {
-  percentileToString
-} from '../../utils/utils';
+import { percentileToString } from '../../utils/utils';
 
 import vars from '../../variables/Variables';
 import emptyImage from '../../assets/img/images/graphs/empty.svg';
 
-const EmptyLabel = props => {
+const EmptyLabel = (props) => {
   return (
     <div className="graph-empty">
       <div className="graph-empty-content">
@@ -28,90 +26,125 @@ const EmptyLabel = props => {
   );
 };
 
-const MobileTooltip = props => {
-  const {active, payload, label } = props;
+const MobileTooltip = (props) => {
+  const { active, payload, label } = props;
   if (active && payload) {
     const denominator = props.denominator;
     const percentile = props.selectedPercentiles;
     const numerator = percentile ? props.selectedPercentiles.numerator : 0;
-    const percentileLow = percentile ? percentileToString(percentile.percentile_low) : 0;
-    const percentileHigh = percentile ? percentileToString(percentile.percentile_high): 0;
+    const percentileLow = percentile
+      ? percentileToString(percentile.percentile_low)
+      : 0;
+    const percentileHigh = percentile
+      ? percentileToString(percentile.percentile_high)
+      : 0;
 
     return (
       <div className="grades-graph-tooltip">
         <h6> Grade: {label} </h6>
-        <p style={{ color: props.color }}> {props.course} • {props.semester} • {props.instructor}</p>
-        <p> {percentileLow} - {percentileHigh} percentile </p>
-        <p>{numerator}/{denominator}</p>
+        <p style={{ color: props.color }}>
+          {props.course} • {props.semester} • {props.instructor}
+        </p>
+        <p>
+          {percentileLow} - {percentileHigh} percentile
+        </p>
+        <p>
+          {numerator}/{denominator}
+        </p>
       </div>
     );
   }
   return null;
 };
 
-const PercentageLabel = props => {
-    //todo: change text color
-    const {x, y, width, value} = props
-    let percentage = value === 0 ? "": (value < 1 ? "<1%" : Math.round(value * 10) / 10 + "%");
-    return (
-      <text
-        x={x + width}
-        y={y}
-        dx={20}
-        dy={15}
-        fontSize={12}
-        textAnchor="middle">{percentage}
-      </text>
-    );
-  };
+const PercentageLabel = (props) => {
+  //todo: change text color
+  const { x, y, width, value } = props;
+  let percentage =
+    value === 0 ? '' : value < 1 ? '<1%' : Math.round(value * 10) / 10 + '%';
+  return (
+    <text x={x + width} y={y} dx={20} dy={15} fontSize={12} textAnchor="middle">
+      {percentage}
+    </text>
+  );
+};
 
 export default function GradesGraph({
-  graphData, gradesData, updateBarHover, updateGraphHover, course, semester, instructor, selectedPercentiles, denominator, color, isMobile, graphEmpty,
+  graphData,
+  gradesData,
+  updateBarHover,
+  updateGraphHover,
+  course,
+  semester,
+  instructor,
+  selectedPercentiles,
+  denominator,
+  color,
+  isMobile,
+  graphEmpty,
 }) {
-
   let numClasses = gradesData.length;
 
   return (
-      <div>
+    <div>
       {!isMobile ? (
+        // desktop or wide viewport
         <ResponsiveContainer width="100%" height={400}>
-          <BarChart data={graphData} onMouseMove={updateGraphHover} margin={{ top: 0, right: 0, left: -15, bottom: 0 }} >
-            <XAxis dataKey="name" />
-            { !graphEmpty ?
-              <YAxis type="number" unit="%" /> : <YAxis type="number" unit="%" domain={[0, 100]}/>
-            }
+          <BarChart
+            data={graphData}
+            onMouseMove={updateGraphHover}
+            margin={{ top: 0, right: 0, left: -15, bottom: 0 }}
+          >
+            <XAxis dataKey="name" type="category" interval={0}  />
+            {!graphEmpty ? (
+              <YAxis type="number" unit="%" />
+            ) : (
+              <YAxis type="number" unit="%" domain={[0, 100]} />
+            )}
 
             <Tooltip
-              formatter={(value, name) => [`${Math.round(value * 10) / 10}%`, name]}
-              cursor={graphEmpty ? {fill: '#fff'} : {fill: '#EAEAEA'}}
+              formatter={(value, name) => [
+                `${Math.round(value * 10) / 10}%`,
+                name,
+              ]}
+              cursor={graphEmpty ? { fill: '#fff' } : { fill: '#EAEAEA' }}
             />
 
-            {!graphEmpty && gradesData.map((item, i) => (
-              <Bar
-                key={i}
-                name={`${item.title} • ${item.semester} • ${item.instructor}`}
-                dataKey={item.id}
-                fill={vars.colors[item.colorId]}
-                onMouseEnter={updateBarHover}
-                radius={[4, 4, 0, 0]}
-              />
-            ))}
+            {!graphEmpty &&
+              gradesData.map((item, i) => (
+                <Bar
+                  key={i}
+                  name={`${item.title} • ${item.semester} • ${item.instructor}`}
+                  dataKey={item.id}
+                  fill={vars.colors[item.colorId]}
+                  onMouseEnter={updateBarHover}
+                  radius={[4, 4, 0, 0]}
+                />
+              ))}
           </BarChart>
         </ResponsiveContainer>
       ) : (
-        <ResponsiveContainer width="95%" height={!graphEmpty ? numClasses*500 : 600} >
+        // mobile or narrow viewport
+        <ResponsiveContainer
+          width="95%"
+          height={!graphEmpty ? (200 + numClasses * 400) : 600}
+        >
           <BarChart
             data={graphData}
             onMouseMove={updateGraphHover}
             layout="vertical"
-            barSize={30}
-            margin={{left: -30, bottom: 50}}
+            // barSize={30}
+            // barCategoryGap={40}
+            // barGap={4}
+            margin={{ left: -30, bottom: 50 }}
           >
-            { !graphEmpty ?
-              <XAxis type="number" unit="%" /> : <XAxis type="number" unit="%" domain={[0, 100]}/>
-            }
-            <YAxis dataKey="name" type="category" />
-            { !graphEmpty ?
+            {!graphEmpty ? (
+              <XAxis type="number" unit="%" />
+            ) : (
+              <XAxis type="number" unit="%" domain={[0, 100]} />
+            )}
+            <YAxis dataKey="name" type="category" interval={0} />
+            {!graphEmpty ? (
               <Tooltip
                 content={
                   <MobileTooltip
@@ -123,8 +156,8 @@ export default function GradesGraph({
                     denominator={denominator}
                   />
                 }
-              /> : null
-            }
+              />
+            ) : null}
             {gradesData.map((item, i) => (
               <Bar
                 key={i}
@@ -133,24 +166,26 @@ export default function GradesGraph({
                 fill={vars.colors[item.colorId]}
                 onMouseEnter={updateBarHover}
                 label={<PercentageLabel />}
+                radius={[0, 4, 4, 0]}
               />
             ))}
             <Legend
-              wrapperStyle={{ paddingTop: 20, paddingLeft: 10, paddingRight: 10, paddingBottom: 10 }}
+              wrapperStyle={{
+                paddingTop: 20,
+                paddingLeft: 10,
+                paddingRight: 10,
+                paddingBottom: 10,
+              }}
               layout="vertical"
+              verticalAlign="top"
               iconSize="10"
               iconType="circle"
             />
           </BarChart>
         </ResponsiveContainer>
-       )
-      }
+      )}
 
-      { graphEmpty &&
-        <EmptyLabel />
-      }
-
-      </div>
-
+      {graphEmpty && <EmptyLabel />}
+    </div>
   );
 }


### PR DESCRIPTION
These were the problems that I had with the mobile version of the grades graph which I fixed

- square corners on bars instead of matching desktop version
- tooltip had weird thick border and square corners instead of matching desktop version
- when comparing classes, gap between bars within one grade bin was bigger than gab between different grade bins
- the numerical label on the widest bar would often get cut off
- the legend was at the bottom so I think mobile users would be confused until they scrolled all the way down (so I moved it to the top, but lmk if you disagree with that)
- grade axis would often only label every other category like A+, A-, B, C+, C-, even though there was space to just label all of them and make the graph less confusing
- one missing space in "Course Average A-(GPA: 3.709)" <- between the grade letter and the (GPA...)
- code formatting (I did the formatting in a separate commit so that you can select just the other commits to see the important diffs)

Before:
<img width="670" alt="scrot 20" src="https://user-images.githubusercontent.com/16441620/193379908-1fe46728-0880-4ff4-9a7d-a59d47e1045b.png">
<img width="720" alt="scrot 22" src="https://user-images.githubusercontent.com/16441620/193379911-94ca7022-7144-4772-8fb3-ac2adc8e2de3.png">

After:
<img width="670" alt="scrot 18" src="https://user-images.githubusercontent.com/16441620/193379913-17601d4d-5bf3-433d-9ec2-02a67efcfe0a.png">
<img width="720" alt="scrot 21" src="https://user-images.githubusercontent.com/16441620/193379920-b127193d-c8e4-4645-9127-5f6927b7b2cc.png">

Note, one weird thing that I didn't fix (because it ended up being harder than expected) is that, when comparing two classes, the tooltip on mobile only shows info for one class instead of for both. The mobile tooltip uses different code than desktop because it adds more info about percentiles to replace the info that's over to the right on desktop. On mobile, you can still see the info for each class by tapping on the different bars, but in a narrow desktop window, that doesn't work because of the way the bars respond to hovers, so you just can't get it to show the percentiles for one of the classes. I'm not sure if that bug/weirdness is worth fixing.
