### PR TITLE
Update Scheduler Title

### DIFF
--- a/frontend/src/components/Scheduler/CourseSelector.tsx
+++ b/frontend/src/components/Scheduler/CourseSelector.tsx
@@ -69,7 +69,7 @@ const CourseSelector = ({
 
   return (
     <div className="course-selector">
-      <h2>Build Schedule</h2>
+      <h2>{semester.semester.charAt(0).toUpperCase() + semester.semester.slice(1)} {semester.year} Scheduler</h2>
       <BTSelect
         isVirtual
         value={null}


### PR DESCRIPTION
Replaces "Build Schedule" with an informative title such as "Fall 2022 Scheduler" so that students are able to determine which semester's classes they are looking at.