### PR TITLE
chore: add dev override for latest semester

### DIFF
--- a/frontend/src/graphql/hooks/semester.ts
+++ b/frontend/src/graphql/hooks/semester.ts
@@ -1,12 +1,12 @@
 import { useGetSemestersQuery } from '../graphql';
+import { ApolloError } from '@apollo/client';
+import { getNodes } from 'utils/graphql';
 import {
   getLatestSemester,
   Semester,
   semesterToString,
   SemesterWithPlaylist,
 } from 'utils/playlists/semesters';
-import { ApolloError } from '@apollo/client';
-import { getNodes } from 'utils/graphql';
 
 /**
  * Gets the latest semester or a populated semester. Does not run a query if the
@@ -33,6 +33,12 @@ export const useSemester = (
     latestSemester = semester as SemesterWithPlaylist;
   } else if (data?.allPlaylists && data.allPlaylists.edges.length >= 1) {
     latestSemester = getLatestSemester(getNodes(data.allPlaylists));
+  }
+
+  // Overriding the latest semester because the dev db has data from 2020
+  if (process.env.NODE_ENV === 'development' && latestSemester) {
+    latestSemester.semester = 'fall';
+    latestSemester.year = '2020';
   }
 
   return { semester: latestSemester, loading, error };


### PR DESCRIPTION
The seed data for local development is from 2020. Adjusting the `useSemester` hook to return `fall 2020` if it's in a development environment. 

Scheduler should now show section data: 

![image](https://user-images.githubusercontent.com/68758451/196882269-c4c18f84-cb00-4233-9ecc-168ab1a5631f.png)
