### PR TITLE
use Fa20 for local dev semester

### DIFF
--- a/frontend/src/utils/playlists/semesters.ts
+++ b/frontend/src/utils/playlists/semesters.ts
@@ -28,7 +28,7 @@ export function getLatestSemester(
   playlists: FilterablePlaylist[]
 ): SemesterWithPlaylist | null {
   const semesterPlaylists = playlists
-    .filter((p) => p.category === 'semester')
+    .filter((p) => p.category === 'semester' && (process.env.NODE_ENV !== 'development' || p.name === 'Fall 2020'))
     .sort((a, b) => playlistToTimeComparable(b) - playlistToTimeComparable(a));
 
   const semester = semesterPlaylists[0];


### PR DESCRIPTION
For local development, forces latest semester to be Fall 2020 to match dummy data.