### PR TITLE
Update graphql.ts

### DIFF
--- a/frontend/src/graphql/hooks/graphql.ts
+++ b/frontend/src/graphql/hooks/graphql.ts
@@ -6,6 +6,7 @@ import {
   MutationResult,
   MutationTuple,
   QueryTuple,
+  OperationVariables
 } from '@apollo/client';
 import { useCallback } from 'react';
 
@@ -43,7 +44,7 @@ export const wrapMutation = <
  */
 export const wrapLazyQuery = <
   LazyQuery extends unknown,
-  LazyQueryVariables extends unknown,
+  LazyQueryVariables extends OperationVariables,
   HookParameters extends any[]
 >(
   lazyQuery: (


### PR DESCRIPTION
Addresses the compile error:
`Type 'LazyQueryVariables' does not satisfy the constraint`