### PR TITLE
[bug] fix course context being cleared on ENROLL_RESET

### DIFF
--- a/frontend/src/redux/reducers/enrollment.js
+++ b/frontend/src/redux/reducers/enrollment.js
@@ -21,7 +21,10 @@ const initialState = {
 export default function enrollment(state = initialState, action) {
 	switch (action.type) {
 		case ENROLL_RESET: {
-			return initialState;
+			return {
+				...initialState,
+				context: state.context
+			};
 		}
 		case UPDATE_ENROLL_CONTEXT: {
 			const { data } = action.payload;


### PR DESCRIPTION
No courses appear when navigating to the enrollment page naturally.

The current implementation of the enrollment page relies on a race condition that the enrollment data fetch will not finish before a subsequent `ENROLL_RESET` redux action finishes. Though if the fetch did somehow finish before the action dispatch, the course list on the enrollment page **would** be empty.

In any case, I made a change with the catalog rework that moved the enrollment fetch earlier in the lifecycle of the application because the catalog, grades, and enrollment pages all rely on the query. By moving it up, all of those critical pages get access to the data without having to fetch it.

What's happening here is that the fetch query is being made, but it is being deduped because the data is already in the store. Because of this, no new request is being made but the `ENROLL_RESET` action is still happening, which clears the course data required for the enrollment page to function.

In this fix, we modify the `ENROLL_RESET` action to keep the course data since it never changes and does not need to be reset across page loads.

### Reproduce
Go to berkeleytime.com
go to enrollment page
No courses appear