### PR TITLE
Fall 2023 new semester updates

### DIFF
--- a/backend/berkeleytime/config/finals/semesters/fall2023.py
+++ b/backend/berkeleytime/config/finals/semesters/fall2023.py
@@ -1,0 +1,56 @@
+from berkeleytime.config.finals.finals import *
+from berkeleytime.config.finals.finals_general import FINAL_TIMES
+
+# CHANGE THESE DICTIONARIES SEMESTER TO SEMESTER AND TRIPLE CHECK THAT THEY ARE RIGHT
+# Source: https://registrar.berkeley.edu/scheduling/academic-scheduling/final-exam-guide-schedules
+
+MWF_FINALS = {
+    datetime.time(8, 0): FINAL_TIMES["Monday7-10PM"],
+    datetime.time(9, 0): FINAL_TIMES["Thursday7-10PM"],
+    datetime.time(10, 0): FINAL_TIMES["Monday8-11AM"],
+    datetime.time(11, 0): FINAL_TIMES["Monday11:30-2:30PM"],
+    datetime.time(12, 0): FINAL_TIMES["Thursday11:30-2:30PM"],
+    datetime.time(13, 0): FINAL_TIMES["Wednesday7-10PM"],
+    datetime.time(14, 0): FINAL_TIMES["Thursday3-6PM"],
+    datetime.time(15, 0): FINAL_TIMES["Tuesday7-10PM"],
+    datetime.time(16, 0): FINAL_TIMES["Thursday8-11AM"],
+    datetime.time(17, 0): FINAL_TIMES["Friday3-6PM"]
+}
+
+TR_FINALS = {
+    datetime.time(8, 0): FINAL_TIMES["Wednesday3-6PM"],
+    datetime.time(9, 0): FINAL_TIMES["Tuesday3-6PM"],
+    datetime.time(10, 0): FINAL_TIMES["Friday3-6PM"],
+    datetime.time(11, 0): FINAL_TIMES["Wednesday8-11AM"],
+    datetime.time(12, 0): FINAL_TIMES["Friday8-11AM"],
+    datetime.time(13, 0): FINAL_TIMES["Friday8-11AM"],
+    datetime.time(14, 0): FINAL_TIMES["Tuesday8-11AM"],
+    datetime.time(15, 0): FINAL_TIMES["Friday7-10PM"],
+    datetime.time(16, 0): FINAL_TIMES["Friday7-10PM"],
+    datetime.time(17, 0): FINAL_TIMES["Thursday11:30-2:30PM"]
+}
+
+HARD_CODED = [
+    ("ECON", ['1', '100B'], FINAL_TIMES.get("Tuesday11:30-2:30PM")),
+    ("UGBA", ["101B"], FINAL_TIMES.get("Tuesday11:30-2:30PM")),
+    ("CHEM", ["1A", "1B", "3A", "3B", "4A", "4B"], FINAL_TIMES.get("Monday3-6PM")),
+    ("ECON", ["140"], FINAL_TIMES.get("Monday3-6PM")),
+    ("ENGLISH", ['1A', '1B', 'R1A', 'R1B'], FINAL_TIMES.get("Friday3-6PM")),
+]
+
+# Mapper function for final times
+def fall_2023_finals_logic(abbreviation, course_number, start_time, is_foreign_language, day_string):
+    for dept, numbers, time in HARD_CODED:
+        if dept == abbreviation and course_number in numbers:
+            return time
+    if is_foreign_language or course_number[0] == "W":
+        return FINAL_TIMES.get("Wednesday11:30-2:30PM")
+    elif day_string == MWF:
+        return MWF_FINALS.get(start_time)
+    elif day_string == TR:
+        return TR_FINALS.get(start_time)
+    elif is_weekend_class(day_string):
+        return FINAL_TIMES.get("Wednesday3-6PM")
+    return None
+
+finals_mapper = FinalTimesMapper(fall_2023_finals_logic)

--- a/backend/berkeleytime/config/finals/semesters/fall2023.py
+++ b/backend/berkeleytime/config/finals/semesters/fall2023.py
@@ -9,7 +9,7 @@ MWF_FINALS = {
     datetime.time(9, 0): FINAL_TIMES["Thursday7-10PM"],
     datetime.time(10, 0): FINAL_TIMES["Monday8-11AM"],
     datetime.time(11, 0): FINAL_TIMES["Monday11:30-2:30PM"],
-    datetime.time(12, 0): FINAL_TIMES["Thursday11:30-2:30PM"],
+    datetime.time(12, 0): FINAL_TIMES["Friday11:30-2:30PM"],
     datetime.time(13, 0): FINAL_TIMES["Wednesday7-10PM"],
     datetime.time(14, 0): FINAL_TIMES["Thursday3-6PM"],
     datetime.time(15, 0): FINAL_TIMES["Tuesday7-10PM"],

--- a/backend/berkeleytime/config/general.py
+++ b/backend/berkeleytime/config/general.py
@@ -21,6 +21,7 @@ from berkeleytime.config.semesters import (
     spring2022,
     fall2022,
     spring2023,
+    fall2023,
 )
 
 GRADE_POINT = {
@@ -60,6 +61,7 @@ PAST_SEMESTERS = [
     {'semester': 'fall', 'year': '2021', 'display': 'Fall 2021'},
     {'semester': 'spring', 'year': '2022', 'display': 'Spring 2022'},
     {'semester': 'fall', 'year': '2022', 'display': 'Fall 2022'},
+    {'semester': 'spring', 'year': '2023', 'display': 'Spring 2023'},
 ]
 
 PAST_SEMESTERS_SIS = [
@@ -76,6 +78,7 @@ PAST_SEMESTERS_SIS = [
     {'semester': 'fall', 'year': '2021', 'display': 'Fall 2021'},
     {'semester': 'spring', 'year': '2022', 'display': 'Spring 2022'},
     {'semester': 'fall', 'year': '2022', 'display': 'Fall 2022'},
+    {'semester': 'spring', 'year': '2023', 'display': 'Spring 2023'},
 ]
 
 
@@ -103,6 +106,7 @@ PAST_SEMESTERS_TELEBEARS_JSON = {
     'spring 2022': spring2022.TELEBEARS_JSON,
     'fall 2022': fall2022.TELEBEARS_JSON,
     'spring 2023': spring2023.TELEBEARS_JSON,
+    'fall 2023': fall2023.TELEBEARS_JSON,
 }
 
 PAST_SEMESTERS_TELEBEARS = {
@@ -127,6 +131,7 @@ PAST_SEMESTERS_TELEBEARS = {
     'spring 2022': spring2022.TELEBEARS,
     'fall 2022': fall2022.TELEBEARS,
     'spring 2023': spring2023.TELEBEARS,
+    'fall 2023': fall2023.TELEBEARS,
 }
 
 # Classes with special characters

--- a/backend/berkeleytime/config/semesters/fall2023.py
+++ b/backend/berkeleytime/config/semesters/fall2023.py
@@ -8,7 +8,7 @@ CURRENT_YEAR = '2023'
 CURRENT_SEMESTER_DISPLAY = 'Fall 2023'
 
 # SIS API Keys
-SIS_TERM_ID = 2228
+SIS_TERM_ID = 2238
 
 TELEBEARS = {
     'phase1_start': datetime.datetime(2023, 4, 17),

--- a/backend/berkeleytime/config/semesters/fall2023.py
+++ b/backend/berkeleytime/config/semesters/fall2023.py
@@ -1,0 +1,42 @@
+"""Configurations for Fall 2023."""
+from berkeleytime.config.finals.semesters.fall2023 import *
+
+import datetime
+
+CURRENT_SEMESTER = 'fall'
+CURRENT_YEAR = '2023'
+CURRENT_SEMESTER_DISPLAY = 'Fall 2023'
+
+# SIS API Keys
+SIS_TERM_ID = 2228
+
+TELEBEARS = {
+    'phase1_start': datetime.datetime(2023, 4, 17),
+    'phase1_end': datetime.datetime(2023, 6, 16),
+    'phase2_start': datetime.datetime(2023, 7, 17),
+    'phase2_end': datetime.datetime(2023, 8, 13),
+
+    'adj_start': datetime.datetime(2023, 8, 14),
+}
+
+INSTRUCTION = {
+    'instruction_start': datetime.datetime(2023, 8, 23, 00, 00),
+    'instruction_end': datetime.datetime(2023, 12, 8, 00, 00)
+}
+
+# Please don't edit anything below this line unless you know what you are doing
+
+TELEBEARS_JSON = {
+    'phase1_start_date': TELEBEARS['phase1_start'].strftime('%m/%d/%Y-%H:%M:%S'),
+    'phase1_end_date': TELEBEARS['phase1_end'].strftime('%m/%d/%Y-%H:%M:%S'),
+    'phase1_start_day': 1,
+    'phase1_end_date': (TELEBEARS['phase1_end'] - TELEBEARS['phase1_start']).days + 1,
+    'phase2_start_date': TELEBEARS['phase2_start'].strftime('%m/%d/%Y-%H:%M:%S'),
+    'phase2_end_date': TELEBEARS['phase2_end'].strftime('%m/%d/%Y-%H:%M:%S'),
+    'phase2_start_day': (TELEBEARS['phase2_start'] - TELEBEARS['phase1_start']).days + 1,
+    'phase2_end_date': (TELEBEARS['phase2_end'] - TELEBEARS['phase1_start']).days + 1,
+    'adj_start_date': TELEBEARS['adj_start'].strftime('%m/%d/%Y-%H:%M:%S'),
+    'adj_start_day': (TELEBEARS['adj_start'] - TELEBEARS['phase1_start']).days + 1,
+}
+
+TELEBEARS_ALREADY_STARTED = datetime.datetime.now() >= TELEBEARS['phase1_start']

--- a/backend/berkeleytime/settings.py
+++ b/backend/berkeleytime/settings.py
@@ -19,7 +19,7 @@ from datetime import timedelta
 from urllib.parse import urlparse
 
 from berkeleytime.config.general import *
-from berkeleytime.config.semesters.spring2023 import *
+from berkeleytime.config.semesters.fall2023 import *
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent

--- a/backend/playlist/utils/config/abbreviation.yaml
+++ b/backend/playlist/utils/config/abbreviation.yaml
@@ -147,6 +147,9 @@ COM LIT:
 COMPSCI:
     - "Computer Science"
 
+CPH:
+    - "Computational Precision Health"
+
 CRIT TH:
     - "Critical Theory"
     - "Critical Theory Graduate Group"
@@ -205,6 +208,143 @@ ALTAIC:
 
 EAEURST:
     - "East European Studies"
+
+EAPAFST:
+    - "African Studies EAP"
+EAPAGSC:
+    - "Agricultural Sciences EAP"
+EAPAMST:
+    - "American Studies EAP"
+EAPANTH:
+    - "Anthropology EAP"
+EAPARAB:
+    - "Arabic EAP"
+EAPARCH:
+    - "Architecture EAP"
+EAPARCOL:
+    - "Archaeology EAP"
+EAPARTHS:
+    - "Art History EAP"
+EAPARTST:
+    - "Art Studio EAP"
+EAPASST:
+    - "Asian Studies EAP"
+EAPBIOE:
+    - "Bioengineering EAP"
+EAPBIOL:
+    - "Biological Sciences EAP"
+EAPBUSA:
+    - "Business Administration EAP"
+EAPCELT:
+    - "Celtic Studies EAP"
+EAPCHEM:
+    - "Chemistry EAP"
+EAPCHIN:
+    - "Chinese EAP"
+EAPCIVE:
+    - "Civil Engineering EAP"
+EAPCLASS:
+    - "Classics EAP"
+EAPCLIT:
+    - "Comparative Literature EAP"
+EAPCOMM:
+    - "Communication EAP"
+EAPCPS:
+    - "Computer Science EAP"
+EAPDA:
+    - "Dramatic Arts  EAP"
+EAPDAN:
+    - "Danish EAP"
+EAPDANCE:
+    - "Dance EAP"
+EAPDEV:
+    - "Development Studies EAP"
+EAPDUTCH:
+    - "Dutch  EAP"
+EAPEARTH:
+    - "Earth and Space Sciences  EAP"
+EAPECON:
+    - "Economics EAP"
+EAPED:
+    - "Education EAP"
+EAPEE:
+    - "Electrical Engineering EAP"
+EAPENGL:
+    - "English EAP"
+EAPENGR:
+    - "Engineering EAP"
+EAPENVS:
+    - "Environmental Studies EAP"
+EAPETHST:
+    - "Ethnic Studies EAP"
+EAPEURS:
+    - "European Studies EAP"
+EAPFILM:
+    - "Film and Media Studies EAP"
+EAPFR:
+    - "French EAP"
+EAPGEOG:
+    - "Geography EAP"
+EAPGER:
+    - "German EAP"
+EAPHINDI:
+    - "Hindi EAP"
+EAPHIST:
+    - "History EAP"
+EAPHLTHS:
+    - "Health Sciences EAP"
+EAPINTL:
+    - "International Studies EAP"
+EAPITAL:
+    - "Italian EAP"
+EAPJAPAN:
+    - "Japanese EAP"
+EAPKOR:
+    - "Korean EAP"
+EAPLATAS:
+    - "Latin American Studies EAP"
+EAPLATIN:
+    - "Latin EAP"
+EAPLEGST:
+    - "Legal Studies EAP"
+EAPLING:
+    - "Linguistics EAP"
+EAPMATH:
+    - "Mathematics EAP"
+EAPME:
+    - "Mechanical Engineering EAP"
+EAPMUS:
+    - "Music EAP"
+EAPNEST:
+    - "Near East Studies EAP"
+EAPPA:
+    - "Physical Activities EAP"
+EAPPHIL:
+    - "Philosophy EAP"
+EAPPHYS:
+    - "Physics EAP"
+EAPPOLS:
+    - "Political Science EAP"
+EAPPSY:
+    - "Psychology EAP"
+EAPRGST:
+    - "Religious Studies EAP"
+EAPSCAND:
+    - "Scandinavian EAP"
+EAPSLAVC:
+    - "Slavic Studies EAP"
+EAPSOC:
+    - "Sociology EAP"
+EAPSPAN:
+    - "Spanish EAP"
+EAPSTAT:
+    - "Statistics EAP"
+EAPSWED:
+    - "Swedish EAP"
+EAPTHAI:
+    - "Thai EAP"
+EAPURBS:
+    - "Urban Studies EAP"
 
 ECON:
     - "Economics"

--- a/frontend/src/utils/scheduler/scheduler.ts
+++ b/frontend/src/utils/scheduler/scheduler.ts
@@ -176,7 +176,7 @@ export const serializeSchedule = (schedule: Schedule, semester: Semester): Backe
  */
 export function scheduleToICal(schedule: Schedule, semester: Semester): string {
 	const SEMESTER_START = new Date(2023, 7, 23);
-	const LAST_COURSE_DAY = new Date(2023, 11, 8);
+	const LAST_COURSE_DAY = new Date(2023, 11, 1);
 
 	const dateToICal = (date: Date) => date.toISOString().replace(/[-:Z]|\.\d+/g, '');
 

--- a/frontend/src/utils/scheduler/scheduler.ts
+++ b/frontend/src/utils/scheduler/scheduler.ts
@@ -175,8 +175,8 @@ export const serializeSchedule = (schedule: Schedule, semester: Semester): Backe
  * Generates iCal file string.
  */
 export function scheduleToICal(schedule: Schedule, semester: Semester): string {
-	const SEMESTER_START = new Date(2023, 0, 17);
-	const LAST_COURSE_DAY = new Date(2023, 4, 6);
+	const SEMESTER_START = new Date(2023, 7, 23);
+	const LAST_COURSE_DAY = new Date(2023, 11, 8);
 
 	const dateToICal = (date: Date) => date.toISOString().replace(/[-:Z]|\.\d+/g, '');
 


### PR DESCRIPTION
- Did the normal stuff identified in the [associated wiki page](https://github.com/asuc-octo/berkeleytime/wiki/New-Semester-Runbook), as in PRs for [Spring 2023](https://github.com/asuc-octo/berkeleytime/pull/529), [Fall 2022](https://github.com/asuc-octo/berkeleytime/pull/489), [Spring 2022](https://github.com/asuc-octo/berkeleytime/pull/472), [Fall 2021](https://github.com/asuc-octo/berkeleytime/pull/453/files), *etc*.
- Also added abbreviations. Most of these were for [EAP](https://uceap.universityofcalifornia.edu/) courses, which showed up in data for Spring 2022, Fall 2022, and Spring 2023. Also added [Computational Precision Health](https://computationalhealth.berkeley.edu/), which showed up in Spring 2023.
- Also updated term start and end dates for exporting schedule to calendar. Found via [this PR](https://github.com/asuc-octo/berkeleytime/pull/501). We don't need to be hard coding these values; there is a PR to generate them dynamically [here](https://github.com/asuc-octo/berkeleytime/pull/506) and I think we should revisit that soon. CC @mathhulk on this last point