### PR TITLE
Auto-fill course selection on enrollment and grade URL navigation

### DIFF
--- a/frontend/src/components/ClassSearchBar/EnrollmentSearchBar.jsx
+++ b/frontend/src/components/ClassSearchBar/EnrollmentSearchBar.jsx
@@ -13,7 +13,8 @@ class EnrollmentSearchBar extends Component {
 		this.state = {
 			selectedClass: 0,
 			selectPrimary: this.props.selectPrimary,
-			selectSecondary: this.props.selectSecondary
+			selectSecondary: this.props.selectSecondary,
+			selectedClassValue: undefined
 		};
 
 		this.queryCache = {};
@@ -29,13 +30,6 @@ class EnrollmentSearchBar extends Component {
 		this.reset = this.reset.bind(this);
 	}
 
-	componentDidMount() {
-		let { fromCatalog } = this.props;
-		if (fromCatalog) {
-			this.handleClassSelect({ value: fromCatalog.id, addSelected: true });
-		}
-	}
-
 	UNSAFE_componentWillReceiveProps(nextProps) {
 		if (nextProps.selectPrimary !== this.state.selectPrimary) {
 			this.setState({
@@ -46,6 +40,23 @@ class EnrollmentSearchBar extends Component {
 			this.setState({
 				selectSecondary: nextProps.selectSecondary
 			});
+		}
+	}
+
+	componentDidUpdate(prevProps) {
+		const { selectedCourses, fetchEnrollSelected } = this.props;
+
+		if (
+			prevProps.selectedCourses != selectedCourses &&
+			Array.isArray(selectedCourses) &&
+			selectedCourses.length > 0
+		) {
+			const course = selectedCourses[selectedCourses.length - 1];
+			const payload = { value: course.courseID, label: course.course, course };
+
+			fetchEnrollSelected(payload);
+
+			this.setState({ selectedClassValue: payload, selectedClass: payload.value });
 		}
 	}
 
@@ -210,7 +221,7 @@ class EnrollmentSearchBar extends Component {
 
 	render() {
 		const { classes, isFull, sections, isMobile } = this.props;
-		const { selectPrimary, selectSecondary, selectedClass } = this.state;
+		const { selectPrimary, selectSecondary, selectedClass, selectedClassValue } = this.state;
 		let primaryOptions = this.buildPrimaryOptions(sections);
 		let secondaryOptions = this.buildSecondaryOptions(sections, selectPrimary);
 		let onePrimaryOption = primaryOptions && primaryOptions.length === 1 && selectPrimary;
@@ -247,7 +258,7 @@ class EnrollmentSearchBar extends Component {
 							courseSearch
 							name="selectClass"
 							placeholder="Choose a class..."
-							// value={selectedClass}
+							value={selectedClassValue}
 							options={this.buildCoursesOptions(classes)}
 							onChange={this.handleClassSelect}
 							components={{
@@ -309,11 +320,12 @@ const mapDispatchToProps = (dispatch) => {
 };
 
 const mapStateToProps = (state) => {
-	const { sections, selectPrimary, selectSecondary } = state.enrollment;
+	const { sections, selectPrimary, selectSecondary, selectedCourses } = state.enrollment;
 	return {
 		sections,
 		selectPrimary,
-		selectSecondary
+		selectSecondary,
+		selectedCourses
 	};
 };
 

--- a/frontend/src/components/ClassSearchBar/GradesSearchBar.jsx
+++ b/frontend/src/components/ClassSearchBar/GradesSearchBar.jsx
@@ -19,7 +19,8 @@ class GradesSearchBar extends Component {
 			selectedClass: 0,
 			selectType: 'instructor',
 			selectPrimary: props.selectPrimary,
-			selectSecondary: props.selectSecondary
+			selectSecondary: props.selectSecondary,
+			selectedClassValue: undefined
 		};
 		this.queryCache = {};
 
@@ -36,13 +37,9 @@ class GradesSearchBar extends Component {
 	}
 
 	componentDidMount() {
-		const { fromCatalog } = this.props;
 		this.setState({
 			selectType: 'instructor'
 		});
-		if (fromCatalog) {
-			this.handleClassSelect({ value: fromCatalog.id, addSelected: true });
-		}
 	}
 
 	UNSAFE_componentWillReceiveProps(nextProps) {
@@ -55,6 +52,24 @@ class GradesSearchBar extends Component {
 			this.setState({
 				selectSecondary: nextProps.selectSecondary
 			});
+		}
+	}
+
+	componentDidUpdate(prevProps) {
+		const { selectedCourses, fetchGradeSelected } = this.props;
+
+		if (
+			prevProps.selectedCourses != selectedCourses &&
+			Array.isArray(selectedCourses) &&
+			selectedCourses.length > 0
+		) {
+			const course = selectedCourses[selectedCourses.length - 1];
+			const payload = { value: course.courseID, label: course.course, course };
+
+			this.setState({ selectedClass: payload.value });
+			fetchGradeSelected(payload);
+
+			this.setState({ selectedClassValue: payload })
 		}
 	}
 
@@ -71,7 +86,12 @@ class GradesSearchBar extends Component {
 		}
 
 		this.setState({
-			selectedClass: updatedClass.value
+			selectedClass: updatedClass.value,
+			selectedClassValue: {
+				value: updatedClass.value,
+				label: updatedClass.label,
+				updatedClass
+			}
 		});
 
 		fetchGradeSelected(updatedClass);
@@ -285,7 +305,7 @@ class GradesSearchBar extends Component {
 
 	render() {
 		const { classes, isFull, isMobile } = this.props;
-		const { selectType, selectPrimary, selectSecondary, selectedClass } = this.state;
+		const { selectType, selectPrimary, selectSecondary, selectedClass, selectedClassValue } = this.state;
 		const { sections } = this.props;
 		const primaryOptions = this.buildPrimaryOptions(sections, selectType);
 		const secondaryOptions = this.buildSecondaryOptions(sections, selectType, selectPrimary);
@@ -332,6 +352,7 @@ class GradesSearchBar extends Component {
 					<Col lg={3}>
 						<BTSelect
 							courseSearch
+							value={selectedClassValue}
 							name="selectClass"
 							placeholder="Choose a class..."
 							options={this.buildCoursesOptions(classes)}
@@ -409,11 +430,12 @@ const mapDispatchToProps = (dispatch) => ({
 });
 
 const mapStateToProps = (state) => {
-	const { sections, selectPrimary, selectSecondary } = state.grade;
+	const { sections, selectPrimary, selectSecondary, selectedCourses } = state.grade;
 	return {
 		sections,
 		selectPrimary,
-		selectSecondary
+		selectSecondary,
+		selectedCourses
 	};
 };
 

--- a/frontend/src/components/ClassSearchBar/GradesSearchBar.jsx
+++ b/frontend/src/components/ClassSearchBar/GradesSearchBar.jsx
@@ -66,10 +66,9 @@ class GradesSearchBar extends Component {
 			const course = selectedCourses[selectedCourses.length - 1];
 			const payload = { value: course.courseID, label: course.course, course };
 
-			this.setState({ selectedClass: payload.value });
 			fetchGradeSelected(payload);
 
-			this.setState({ selectedClassValue: payload })
+			this.setState({ selectedClassValue: payload, selectedClass: payload.value });
 		}
 	}
 

--- a/frontend/src/views/Enrollment/Enrollment.jsx
+++ b/frontend/src/views/Enrollment/Enrollment.jsx
@@ -124,7 +124,6 @@ class Enrollment extends Component {
 	render() {
 		const { additionalInfo } = this.state;
 		const { context, selectedCourses, isMobile } = this.props;
-		let { location } = this.props;
 		let courses = context.courses;
 
 		return (
@@ -133,7 +132,6 @@ class Enrollment extends Component {
 					<EnrollmentSearchBar
 						classes={courses}
 						addCourse={this.addCourse}
-						fromCatalog={location.state ? location.state.course : false}
 						isFull={selectedCourses.length === 4}
 						isMobile={isMobile}
 					/>

--- a/frontend/src/views/Grades/Grades.jsx
+++ b/frontend/src/views/Grades/Grades.jsx
@@ -129,7 +129,6 @@ class Grades extends Component {
 
 	render() {
 		const { context, selectedCourses, isMobile } = this.props;
-		let { location } = this.props;
 		const { additionalInfo } = this.state;
 		let courses = context.courses;
 
@@ -139,7 +138,6 @@ class Grades extends Component {
 					<GradesSearchBar
 						classes={courses}
 						addCourse={this.addCourse}
-						fromCatalog={location.state ? location.state.course : false}
 						isFull={selectedCourses.length === 4}
 						isMobile={isMobile}
 					/>


### PR DESCRIPTION
Feature requested by BT user:

> so a common flow is landing page -> explore courses -> look up class -> click average grade button but from there if u want to change it to focus on a certain semester/instructor u have to manually restart the class search at the top, like there's no direct way from here to, say, fall 2020 or smt. same issue holds for the enrollment page. i propose that the fields are either autofilled when u click the popup or there's an edit button added that lets u change the semesters/instructors for each box (like, next to the delete button)

This change updates the select components value when grade or enrollment data is said to be selected.

Changes viewable: https://auto-fill-course.berkeleytime.com/