### PR TITLE
Use staging backend for frontend development

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /frontend
 COPY package.json .
 RUN npm install
 COPY . .
-ENTRYPOINT npm start
+ENTRYPOINT npm dev
 
 FROM dev AS prod
 RUN npm install -g serve

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,7 @@
 		"build:js": "vite build --emptyOutDir",
 		"watch:js": "vite",
 		"watch:codegen": "graphql-codegen --config codegen.yml --watch",
-		"start": "npm-run-all codegen -p watch:*",
+		"dev": "npm-run-all codegen -p watch:*",
 		"build": "npm-run-all codegen -p build:*",
 		"lint": "eslint ./**/* --fix --ext .jsx --ext .tsx --ext .scss",
 		"prod": "serve -s build -p 3000"

--- a/frontend/src/graphql/client.ts
+++ b/frontend/src/graphql/client.ts
@@ -2,7 +2,7 @@ import { ApolloClient, HttpLink } from '@apollo/client';
 import { cache } from './cache';
 
 const httpLink = new HttpLink({
-	uri: '/api/graphql'
+	uri: import.meta.env.PROD ? '/api/graphql' : 'https://staging.berkeleytime.com/api/graphql'
 });
 
 // Explore ways to transform API responses before reaching the components

--- a/frontend/src/redux/actions.js
+++ b/frontend/src/redux/actions.js
@@ -16,6 +16,8 @@ import {
 	UPDATE_ENROLL_SELECTED
 } from './actionTypes';
 
+axios.defaults.baseURL = import.meta.env.PROD ? axios.defaults.baseURL : 'https://staging.berkeleytime.com';
+
 // update grade list
 const updateGradeContext = (data) => ({
 	type: UPDATE_GRADE_CONTEXT,


### PR DESCRIPTION
Modify our api URLs to point toward the staging backend when we are in dev mode. Keep original functionality when in production.

Related #593 

Note intuitive change to use `npm run dev` instead of `start` because its shorter, more intuitive and standard now