### PR TITLE
add browser title data for enrollment and grades

### DIFF
--- a/frontend/src/app/Enrollment/index.jsx
+++ b/frontend/src/app/Enrollment/index.jsx
@@ -7,6 +7,8 @@ import EnrollmentSearchBar from '../../components/ClassSearchBar/EnrollmentSearc
 
 import info from '../../assets/img/images/graphs/info.svg';
 
+import Meta from 'components/Common/Meta';
+
 import {
 	fetchEnrollContext,
 	fetchEnrollClass,
@@ -19,6 +21,10 @@ import { useCallback, useEffect, useState } from 'react';
 const toUrlForm = (s) => {
 	return s.toLowerCase().split(' ').join('-');
 };
+
+const formatMetaTitle = (selectedCourses) =>
+	`Enrollment ${selectedCourses.length > 0 ? `| ${selectedCourses.map((c) => ` ${c.course}`)}` : ''}`;
+
 
 export function Component() {
 	const [additionalInfo, setAdditionalInfo] = useState([]);
@@ -137,6 +143,7 @@ export function Component() {
 
 	return (
 		<div className="viewport-app">
+			<Meta title={formatMetaTitle(selectedCourses)} />
 			<div className="enrollment">
 				<EnrollmentSearchBar
 					classes={context.courses}

--- a/frontend/src/app/Grades/index.jsx
+++ b/frontend/src/app/Grades/index.jsx
@@ -8,6 +8,8 @@ import GradesSearchBar from '../../components/ClassSearchBar/GradesSearchBar';
 
 import info from '../../assets/img/images/graphs/info.svg';
 
+import Meta from 'components/Common/Meta';
+
 import {
 	fetchGradeContext,
 	fetchGradeClass,
@@ -20,6 +22,9 @@ const toUrlForm = (s) => {
 	s = s.replace('/', '_');
 	return s.toLowerCase().split(' ').join('-');
 };
+
+const formatMetaTitle = (selectedCourses) =>
+	`Grades ${selectedCourses.length > 0 ? `| ${selectedCourses.map((c) => ` ${c.course}`)}` : ''}`;
 
 export function Component() {
 	const [additionalInfo, setAdditionalInfo] = useState([]);
@@ -131,6 +136,8 @@ export function Component() {
 
 	return (
 		<div className="viewport-app">
+			<Meta title={formatMetaTitle(selectedCourses)} />
+
 			<div className="grades">
 				<GradesSearchBar
 					classes={context.courses}

--- a/frontend/src/components/Common/Layout.tsx
+++ b/frontend/src/components/Common/Layout.tsx
@@ -5,6 +5,7 @@ import ReactGA from 'react-ga';
 import Navigation from './Navigation';
 import BTLoader from './BTLoader';
 import Footer from './Footer';
+import Meta from './Meta';
 
 ReactGA.initialize('UA-35316609-1');
 
@@ -29,6 +30,7 @@ export default function RootLayout({ footer }: LayoutProps) {
 		<>
 			{/* <Banner /> */}
 			<Navigation />
+			<Meta title="Berkeleytime" />
 			{navigate.state == 'loading' ? (
 				<div className="viewport-app">
 					<BTLoader />


### PR DESCRIPTION
Adds metadata for browser titles while navigating enrollment and grades

![image](https://github.com/asuc-octo/berkeleytime/assets/32107970/e99a7393-e3d0-4c40-91d6-3785b82980e6)
