### PR TITLE
Update ingress-nginx.yaml

### DIFF
--- a/infra/helm/ingress-nginx.yaml
+++ b/infra/helm/ingress-nginx.yaml
@@ -25,7 +25,5 @@ controller:
     # enable-opentracing: "true"
     # datadog-collector-host: $HOST_IP
 tcp:
-  2222: default/bt-gitlab:2222::PROXY
-  5432: default/bt-psql-staging:5432::PROXY
-  6379: default/bt-redis-staging-master:6379::PROXY
-  27017: default/bt-mdb-staging-0-external:27017::PROXY
+  5000: default/bt-gitlab-tcp:5000
+  10000: default/bt-gitlab-tcp:10000


### PR DESCRIPTION
Ran
```console
helm upgrade ingress-nginx ingress-nginx/ingress-nginx --version 3.27.0 -n ingress-nginx --create-namespace -f /berkeleytime/infra/helm/ingress-nginx.yaml
```

After updating it manually

Fixed Docker registry not responding on port 5000

![image](https://github.com/asuc-octo/berkeleytime/assets/22272118/e05d26e2-011c-4f92-a923-a1e8c35a759c)

Check logs:
```kubectl exec -it deploy/bt-gitlab -- cat /var/log/gitlab/registry/current```
