### PR TITLE
use redis to store user session cookies

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -14,6 +14,7 @@
         "@graphql-tools/schema": "^10.0.0",
         "@graphql-tools/utils": "^10.0.7",
         "axios": "^1.5.1",
+        "connect-redis": "^7.1.1",
         "cors": "^2.8.5",
         "dotenv": "^8.2.0",
         "express": "^4.18.2",
@@ -5453,6 +5454,17 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
+    },
+    "node_modules/connect-redis": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/connect-redis/-/connect-redis-7.1.1.tgz",
+      "integrity": "sha512-M+z7alnCJiuzKa8/1qAYdGUXHYfDnLolOGAUjOioB07pP39qxjG+X9ibsud7qUBc4jMV5Mcy3ugGv8eFcgamJQ==",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "express-session": ">=1"
+      }
     },
     "node_modules/constant-case": {
       "version": "3.0.4",

--- a/backend/package.json
+++ b/backend/package.json
@@ -54,6 +54,7 @@
     "@graphql-tools/schema": "^10.0.0",
     "@graphql-tools/utils": "^10.0.7",
     "axios": "^1.5.1",
+    "connect-redis": "^7.1.1",
     "cors": "^2.8.5",
     "dotenv": "^8.2.0",
     "express": "^4.18.2",

--- a/backend/src/bootstrap/loaders/express.ts
+++ b/backend/src/bootstrap/loaders/express.ts
@@ -3,11 +3,12 @@ import cors from "cors";
 import helmet from "helmet";
 import type { ApolloServer } from "@apollo/server";
 import { expressMiddleware } from "@apollo/server/express4";
+import { RedisClientType } from "redis";
 
 import passportLoader from "./passport";
 import { config } from "../../config";
 
-export default async (app: Application, server: ApolloServer) => {
+export default async (app: Application, server: ApolloServer, redis: RedisClientType) => {
   // Body parser only needed during POST on the graphQL path
   app.use(json());
 
@@ -24,7 +25,7 @@ export default async (app: Application, server: ApolloServer) => {
   app.use(helmet());
 
   // load authentication
-  passportLoader(app);
+  passportLoader(app, redis);
 
   app.use(
     config.graphqlPath,

--- a/backend/src/bootstrap/loaders/index.ts
+++ b/backend/src/bootstrap/loaders/index.ts
@@ -24,7 +24,7 @@ export default async (root: Application): Promise<void> => {
 
   // load everything related to express. depends on apollo
   console.log("Loading express...");
-  await expressLoader(app, server);
+  await expressLoader(app, server, redis);
 
   // append backend path to all routes
   root.use(config.backendPath, app);

--- a/backend/src/bootstrap/loaders/passport.ts
+++ b/backend/src/bootstrap/loaders/passport.ts
@@ -11,6 +11,8 @@ import passport from "passport";
 import GoogleStrategy from "passport-google-oauth20";
 import { UserModel } from "../../models/user";
 import { config } from "../../config";
+import type { RedisClientType } from "redis";
+import RedisStore from "connect-redis";
 
 const LOGIN_ROUTE = "/login";
 const LOGIN_REDIRECT_ROUTE = "/login/redirect";
@@ -24,7 +26,9 @@ const FAILURE_REDIRECT = config.backendPath + "/fail";
 
 const SCOPE = ['profile', 'email']
 
-export default async (app: Application) => {
+const CACHE_PREFIX = 'user-session:'
+
+export default async (app: Application, redis: RedisClientType) => {
   // init
   app.use(session({
     secret: config.SESSION_SECRET,
@@ -37,6 +41,10 @@ export default async (app: Application) => {
       maxAge: 1000 * 60 * 60, // 1 hour
       sameSite: 'lax',
     },
+    store: new RedisStore({
+      client: redis,
+      prefix: CACHE_PREFIX,
+    }),
     rolling: true,
   }));
   app.use(passport.initialize());


### PR DESCRIPTION
Adapted from branch [user_redis_cache](https://github.com/asuc-octo/berkeleytime/tree/user_redis_cache) worked on by @JackyJerkyYt. 

Stores user session cookies in Redis instead of in memory (default behavior). After deploying, backend instances can be brought back up from 1. 