### PR TITLE
(cicd) add suspend=true to datapuller in dev cicd

### DIFF
--- a/.github/workflows/cd-dev.yaml
+++ b/.github/workflows/cd-dev.yaml
@@ -57,15 +57,19 @@ jobs:
             tag: '${{ needs.compute-sha.outputs.sha_short }}'
         datapuller:
           courses:
+            suspend: true
             image:
               tag: '${{ needs.compute-sha.outputs.sha_short }}'
           sections:
+            suspend: true
             image:
               tag: '${{ needs.compute-sha.outputs.sha_short }}'
           classes:
+            suspend: true
             image:
               tag: '${{ needs.compute-sha.outputs.sha_short }}'
           grades:
+            suspend: true
             image:
               tag: '${{ needs.compute-sha.outputs.sha_short }}'
         host: ${{ needs.compute-sha.outputs.sha_short }}.dev.stanfurdtime.com


### PR DESCRIPTION
Adds `suspend=true` field to datapuller cronjobs during development deployments. To test a puller, [manually run the cronjobs](https://docs.stanfurdtime.com/core/infrastructure/runbooks.html#manually-run-datapuller). 