### PR TITLE
enrollment datapuller

### DIFF
--- a/.github/workflows/cd-dev.yaml
+++ b/.github/workflows/cd-dev.yaml
@@ -72,6 +72,10 @@ jobs:
             suspend: true
             image:
               tag: '${{ needs.compute-sha.outputs.sha_short }}'
+          enrollments::
+            suspend: true
+            image:
+              tag: '${{ needs.compute-sha.outputs.sha_short }}'
         host: ${{ needs.compute-sha.outputs.sha_short }}.dev.stanfurdtime.com
         mongoUri: mongodb://bt-dev-mongo-mongodb-0.bt-dev-mongo-mongodb-headless.bt.svc.cluster.local:27017/bt
         redisUri: redis://bt-dev-redis-master.bt.svc.cluster.local:6379

--- a/.github/workflows/cd-dev.yaml
+++ b/.github/workflows/cd-dev.yaml
@@ -72,7 +72,7 @@ jobs:
             suspend: true
             image:
               tag: '${{ needs.compute-sha.outputs.sha_short }}'
-          enrollments::
+          enrollments:
             suspend: true
             image:
               tag: '${{ needs.compute-sha.outputs.sha_short }}'

--- a/.github/workflows/cd-stage.yaml
+++ b/.github/workflows/cd-stage.yaml
@@ -45,6 +45,9 @@ jobs:
           grades:
             image:
               tag: latest
+          enrollments:
+            image:
+              tag: latest
         host: staging.stanfurdtime.com
         mongoUri: mongodb://bt-stage-mongo-mongodb-0.bt-stage-mongo-mongodb-headless.bt.svc.cluster.local:27017/bt
         redisUri: redis://bt-stage-redis-master.bt.svc.cluster.local:6379

--- a/apps/datapuller/src/lib/enrollment.ts
+++ b/apps/datapuller/src/lib/enrollment.ts
@@ -1,0 +1,91 @@
+import { Logger } from "tslog";
+
+import { IEnrollmentSingularItem } from "@repo/common";
+import { ClassSection, ClassesAPI } from "@repo/sis-api/classes";
+
+import { fetchPaginatedData } from "./api/sis-api";
+import { filterSection } from "./sections";
+
+export const formatEnrollmentSingular = (input: ClassSection, time: Date) => {
+  const termId = input.class?.session?.term?.id;
+  const sessionId = input.class?.session?.id;
+  const sectionId = input.id?.toString();
+
+  const essentialFields = {
+    termId,
+    sessionId,
+    sectionId,
+  };
+
+  const missingField = Object.keys(essentialFields).find(
+    (key) => !essentialFields[key as keyof typeof essentialFields]
+  );
+
+  if (missingField)
+    throw new Error(`Missing essential section field: ${missingField[0]}`);
+
+  const output: IEnrollmentSingularItem = {
+    termId: termId!,
+    sessionId: sessionId!,
+    sectionId: sectionId!,
+    data: {
+      time: time.toISOString(),
+      status: input.enrollmentStatus?.status?.code,
+      enrolledCount: input.enrollmentStatus?.enrolledCount,
+      reservedCount: input.enrollmentStatus?.reservedCount,
+      waitlistedCount: input.enrollmentStatus?.waitlistedCount,
+      minEnroll: input.enrollmentStatus?.minEnroll,
+      maxEnroll: input.enrollmentStatus?.maxEnroll,
+      maxWaitlist: input.enrollmentStatus?.maxWaitlist,
+      openReserved: input.enrollmentStatus?.openReserved,
+      instructorAddConsentRequired:
+        input.enrollmentStatus?.instructorAddConsentRequired,
+      instructorDropConsentRequired:
+        input.enrollmentStatus?.instructorDropConsentRequired,
+      seatReservations: input.enrollmentStatus?.seatReservations?.map(
+        (reservation) => ({
+          number: reservation.number,
+          maxEnroll: reservation.maxEnroll,
+          enrolledCount: reservation.enrolledCount,
+        })
+      ),
+    },
+    seatReservations: input.enrollmentStatus?.seatReservations?.map(
+      (reservation) => ({
+        number: reservation.number,
+        requirementGroup: reservation.requirementGroup?.description,
+        fromDate: reservation.fromDate,
+      })
+    ),
+  };
+
+  return output;
+};
+
+export const getEnrollmentSingulars = async (
+  logger: Logger<unknown>,
+  id: string,
+  key: string,
+  termIds?: string[]
+) => {
+  const classesAPI = new ClassesAPI();
+
+  const sections = await fetchPaginatedData<
+    IEnrollmentSingularItem,
+    ClassSection
+  >(
+    logger,
+    classesAPI.v1,
+    termIds || null,
+    "getClassSectionsUsingGet",
+    {
+      app_id: id,
+      app_key: key,
+    },
+    (data) => data.apiResponse.response.classSections || [],
+    filterSection,
+    (input) => formatEnrollmentSingular(input, new Date())
+  );
+
+  return sections;
+};

--- a/apps/datapuller/src/lib/sections.ts
+++ b/apps/datapuller/src/lib/sections.ts
@@ -5,7 +5,7 @@ import { ClassSection, ClassesAPI } from "@repo/sis-api/classes";
 
 import { fetchPaginatedData } from "./api/sis-api";
 
-const filterSection = (input: ClassSection): boolean => {
+export const filterSection = (input: ClassSection): boolean => {
   return input.status?.code === "A";
 };
 

--- a/apps/datapuller/src/main.ts
+++ b/apps/datapuller/src/main.ts
@@ -16,7 +16,7 @@ const pullerMap: { [key: string]: (config: Config) => Promise<void> } = {
   courses: updateCourses,
   sections: updateSections,
   classes: updateClasses,
-  "grade-distributions": updateGradeDistributions,
+  grades: updateGradeDistributions,
   enrollments: updateEnrollmentHistories,
   main: main,
 };

--- a/apps/datapuller/src/main.ts
+++ b/apps/datapuller/src/main.ts
@@ -1,5 +1,6 @@
 import updateClasses from "./pullers/classes";
 import updateCourses from "./pullers/courses";
+import updateEnrollmentHistories from "./pullers/enrollment";
 import updateGradeDistributions from "./pullers/grade-distributions";
 import main from "./pullers/main";
 import updateSections from "./pullers/sections";
@@ -16,6 +17,7 @@ const pullerMap: { [key: string]: (config: Config) => Promise<void> } = {
   sections: updateSections,
   classes: updateClasses,
   "grade-distributions": updateGradeDistributions,
+  enrollments: updateEnrollmentHistories,
   main: main,
 };
 

--- a/apps/datapuller/src/pullers/classes.ts
+++ b/apps/datapuller/src/pullers/classes.ts
@@ -16,7 +16,7 @@ const updateClasses = async ({
   );
 
   log.info(
-    `Fetched ${activeTerms.length.toLocaleString()} active terms: ${activeTerms.map((term) => term.name).toLocaleString()}.`
+    `Fetched ${activeTerms.length.toLocaleString()} undergraduate active terms: ${activeTerms.map((term) => term.name).toLocaleString()}.`
   );
 
   log.info(`Fetching classes for active terms`);

--- a/apps/datapuller/src/pullers/enrollment.ts
+++ b/apps/datapuller/src/pullers/enrollment.ts
@@ -1,0 +1,133 @@
+import {
+  IEnrollmentSingularItem,
+  NewEnrollmentHistoryModel,
+} from "@repo/common";
+
+import { getEnrollmentSingulars } from "../lib/enrollment";
+import { getActiveTerms } from "../lib/terms";
+import { Config } from "../shared/config";
+
+// enrollmentSingulars are equivalent if their data points are all equal
+const enrollmentSingularsEqual = (
+  a: IEnrollmentSingularItem["data"],
+  b: IEnrollmentSingularItem["data"]
+) => {
+  const conditions = [
+    a.status === b.status,
+    a.enrolledCount === b.enrolledCount,
+    a.reservedCount === b.reservedCount,
+    a.waitlistedCount === b.waitlistedCount,
+    a.minEnroll === b.minEnroll,
+    a.maxEnroll === b.maxEnroll,
+    a.maxWaitlist === b.maxWaitlist,
+    a.openReserved === b.openReserved,
+    a.instructorAddConsentRequired === b.instructorAddConsentRequired,
+    a.instructorDropConsentRequired === b.instructorDropConsentRequired,
+  ];
+
+  if (
+    a.seatReservations instanceof Array &&
+    b.seatReservations instanceof Array
+  ) {
+    if (a.seatReservations.length !== b.seatReservations.length) return false;
+    for (const aSeats of a.seatReservations) {
+      for (const bSeats of b.seatReservations) {
+        if (aSeats.number === bSeats.number) {
+          conditions.push(aSeats.enrolledCount === bSeats.enrolledCount);
+          conditions.push(aSeats.maxEnroll === bSeats.maxEnroll);
+        }
+      }
+    }
+  } else if (
+    (!(a.seatReservations instanceof Array) &&
+      b.seatReservations instanceof Array) ||
+    (!(a.seatReservations instanceof Array) &&
+      b.seatReservations instanceof Array)
+  ) {
+    return false;
+  }
+
+  return conditions.every((condition) => condition);
+};
+
+const updateEnrollmentHistories = async ({
+  log,
+  sis: { TERM_APP_ID, TERM_APP_KEY, CLASS_APP_ID, CLASS_APP_KEY },
+}: Config) => {
+  log.info(`Fetching active terms.`);
+
+  const allActiveTerms = await getActiveTerms(log, TERM_APP_ID, TERM_APP_KEY); // includes LAW, Graduate, etc. which are duplicates of Undergraduate
+  const activeTerms = allActiveTerms.filter(
+    (term) => term.academicCareer?.description === "Undergraduate"
+  );
+
+  log.info(
+    `Fetched ${activeTerms.length.toLocaleString()} undergraduate active terms: ${activeTerms.map((term) => term.name).toLocaleString()}.`
+  );
+
+  log.info(`Fetching enrollment for active terms.`);
+
+  const enrollmentSingulars = await getEnrollmentSingulars(
+    log,
+    CLASS_APP_ID,
+    CLASS_APP_KEY,
+    activeTerms.map((term) => term.id as string)
+  );
+
+  log.info(
+    `Fetched ${enrollmentSingulars.length.toLocaleString()} enrollments for active terms.`
+  );
+
+  let updateCount = 0;
+  for (const enrollmentSingular of enrollmentSingulars) {
+    const session = await NewEnrollmentHistoryModel.startSession();
+
+    await session.withTransaction(async () => {
+      // find existing history
+      const doc = await NewEnrollmentHistoryModel.findOne(
+        {
+          termId: enrollmentSingular.termId,
+          sessionId: enrollmentSingular.sessionId,
+          sectionId: enrollmentSingular.sectionId,
+        },
+        null,
+        { session }
+      ).lean();
+
+      // skip if no change
+      if (doc && doc.history.length > 0) {
+        const lastHistory = doc.history[doc.history.length - 1];
+        if (enrollmentSingularsEqual(lastHistory, enrollmentSingular.data)) {
+          return;
+        }
+      }
+
+      // append to history array, upsert if needed
+      const op = await NewEnrollmentHistoryModel.updateOne(
+        {
+          termId: enrollmentSingular.termId,
+          sessionId: enrollmentSingular.sessionId,
+          sectionId: enrollmentSingular.sectionId,
+        },
+        {
+          $setOnInsert: {
+            seatReservations: enrollmentSingular.seatReservations,
+          },
+          $push: {
+            history: enrollmentSingular.data,
+          },
+        },
+        { upsert: true, session }
+      );
+      updateCount += op.modifiedCount + op.upsertedCount;
+    });
+
+    session.endSession();
+  }
+
+  log.info(
+    `Completed updating database with ${enrollmentSingulars.length.toLocaleString()} enrollments, modified ${updateCount.toLocaleString()} documents for ${activeTerms.length.toLocaleString()} active terms.`
+  );
+};
+
+export default updateEnrollmentHistories;

--- a/apps/datapuller/src/pullers/sections.ts
+++ b/apps/datapuller/src/pullers/sections.ts
@@ -16,7 +16,7 @@ const updateSections = async ({
   );
 
   log.info(
-    `Fetched ${activeTerms.length.toLocaleString()} active terms: ${activeTerms.map((term) => term.name).toLocaleString()}.`
+    `Fetched ${activeTerms.length.toLocaleString()} undergraduate active terms: ${activeTerms.map((term) => term.name).toLocaleString()}.`
   );
 
   log.info(`Fetching sections for active terms.`);

--- a/infra/app/values.yaml
+++ b/infra/app/values.yaml
@@ -66,7 +66,7 @@ datapuller:
       repository: octoberkeleytime/bt-datapuller
       tag: prod
   enrollments:
-    schedule: "*/15 * * * *"
+    schedule: "0/15 * * * *"
     suspend: false
     puller: "enrollments"
     image:

--- a/infra/app/values.yaml
+++ b/infra/app/values.yaml
@@ -66,7 +66,7 @@ datapuller:
       repository: octoberkeleytime/bt-datapuller
       tag: prod
   enrollments:
-    schedule: "0/15 * * * *"
+    schedule: "0,15,30,45 * * * *"
     suspend: false
     puller: "enrollments"
     image:

--- a/infra/app/values.yaml
+++ b/infra/app/values.yaml
@@ -66,7 +66,7 @@ datapuller:
       repository: octoberkeleytime/bt-datapuller
       tag: prod
   enrollments:
-    schedule: "0,15,30,45 * * * *"
+    schedule: "0/15 * * * *"
     suspend: false
     puller: "enrollments"
     image:

--- a/infra/app/values.yaml
+++ b/infra/app/values.yaml
@@ -60,7 +60,15 @@ datapuller:
   grades:
     schedule: "25 4 * * *"
     suspend: false
-    puller: "grade-distributions"
+    puller: "grades"
+    image:
+      registry: docker.io
+      repository: octoberkeleytime/bt-datapuller
+      tag: prod
+  enrollments:
+    schedule: "*/15 * * * *"
+    suspend: false
+    puller: "enrollments"
     image:
       registry: docker.io
       repository: octoberkeleytime/bt-datapuller

--- a/packages/common/src/models/enrollment-history.ts
+++ b/packages/common/src/models/enrollment-history.ts
@@ -5,7 +5,8 @@ export interface IEnrollmentHistoryItem {
   sessionId: string;
   sectionId: string;
 
-  // maps number to requirementGroup
+  // maps number to requirementGroup.
+  // this assumes that these fields are constant over time.
   seatReservations?: {
     number: number;
     requirementGroup?: string;
@@ -83,7 +84,4 @@ enrollmentHistorySchema.index(
 );
 
 export const NewEnrollmentHistoryModel: Model<IEnrollmentHistoryItem> =
-  model<IEnrollmentHistoryItem>(
-    "NewEnrollmentHistory",
-    enrollmentHistorySchema
-  );
+  model<IEnrollmentHistoryItem>("EnrollmentHistory", enrollmentHistorySchema);

--- a/packages/common/src/models/enrollmentNew.ts
+++ b/packages/common/src/models/enrollmentNew.ts
@@ -46,6 +46,7 @@ const enrollmentHistorySchema = new Schema<IEnrollmentHistoryItem>({
   sectionId: { type: String, required: true },
   history: [
     {
+      _id: false,
       time: { type: String, required: true },
       status: { type: String },
       enrolledCount: { type: Number },
@@ -59,6 +60,7 @@ const enrollmentHistorySchema = new Schema<IEnrollmentHistoryItem>({
       instructorDropConsentRequired: { type: Boolean },
       seatReservations: [
         {
+          _id: false,
           number: { type: Number },
           maxEnroll: { type: Number },
           enrolledCount: { type: Number },
@@ -68,6 +70,7 @@ const enrollmentHistorySchema = new Schema<IEnrollmentHistoryItem>({
   ],
   seatReservations: [
     {
+      _id: false,
       number: { type: Number },
       requirementGroup: { type: String },
       fromDate: { type: String },

--- a/packages/common/src/models/enrollmentNew.ts
+++ b/packages/common/src/models/enrollmentNew.ts
@@ -1,42 +1,50 @@
 import { Document, Model, Schema, model } from "mongoose";
 
-export interface IEnrollmentItem {
+export interface IEnrollmentHistoryItem {
   termId: string;
   sessionId: string;
   sectionId: string;
-  data: [
-    {
-      time: string;
-      status?: string;
+
+  // maps number to requirementGroup
+  seatReservations?: {
+    number: number;
+    requirementGroup?: string;
+    fromDate: string;
+  }[];
+  history: {
+    time: string;
+    status?: string;
+    enrolledCount?: number;
+    reservedCount?: number;
+    waitlistedCount?: number;
+    minEnroll?: number;
+    maxEnroll?: number;
+    maxWaitlist?: number;
+    openReserved?: number;
+    instructorAddConsentRequired?: boolean;
+    instructorDropConsentRequired?: boolean;
+    seatReservations?: {
+      number: number; // maps to seatReservations.number to get requirementGroup
+      maxEnroll: number;
       enrolledCount?: number;
-      reservedCount?: number;
-      waitlistedCount?: number;
-      minEnroll?: number;
-      maxEnroll?: number;
-      maxWaitlist?: number;
-      openReserved?: number;
-      instructorAddConsentRequired?: boolean;
-      instructorDropConsentRequired?: boolean;
-      seatReservations?: [
-        {
-          number?: number;
-          requirementGroup?: string;
-          fromDate?: string;
-          maxEnroll?: number;
-          enrolledCount?: number;
-        },
-      ];
-    },
-  ];
+    }[];
+  }[];
 }
 
-export interface IEnrollmentItemDocument extends IEnrollmentItem, Document {}
+export interface IEnrollmentSingularItem
+  extends Omit<IEnrollmentHistoryItem, "history"> {
+  data: IEnrollmentHistoryItem["history"][0];
+}
 
-const enrollmentSchema = new Schema<IEnrollmentItem>({
+export interface IEnrollmentHistoryItemDocument
+  extends IEnrollmentHistoryItem,
+    Document {}
+
+const enrollmentHistorySchema = new Schema<IEnrollmentHistoryItem>({
   termId: { type: String, required: true },
   sessionId: { type: String, required: true },
   sectionId: { type: String, required: true },
-  data: [
+  history: [
     {
       time: { type: String, required: true },
       status: { type: String },
@@ -52,19 +60,27 @@ const enrollmentSchema = new Schema<IEnrollmentItem>({
       seatReservations: [
         {
           number: { type: Number },
-          requirementGroup: { type: String },
-          fromDate: { type: String },
           maxEnroll: { type: Number },
           enrolledCount: { type: Number },
         },
       ],
     },
   ],
+  seatReservations: [
+    {
+      number: { type: Number },
+      requirementGroup: { type: String },
+      fromDate: { type: String },
+    },
+  ],
 });
-enrollmentSchema.index(
+enrollmentHistorySchema.index(
   { termId: 1, sessionId: 1, sectionId: 1 },
   { unique: true }
 );
 
-export const NewEnrollmentModel: Model<IEnrollmentItem> =
-  model<IEnrollmentItem>("NewEnrollment", enrollmentSchema);
+export const NewEnrollmentHistoryModel: Model<IEnrollmentHistoryItem> =
+  model<IEnrollmentHistoryItem>(
+    "NewEnrollmentHistory",
+    enrollmentHistorySchema
+  );

--- a/packages/common/src/models/index.ts
+++ b/packages/common/src/models/index.ts
@@ -9,4 +9,4 @@ export * from "./sectionNew";
 export * from "./courseNew";
 export * from "./classNew";
 export * from "./grade-distribution";
-export * from "./enrollmentNew";
+export * from "./enrollment-history";

--- a/packages/common/src/models/index.ts
+++ b/packages/common/src/models/index.ts
@@ -9,3 +9,4 @@ export * from "./sectionNew";
 export * from "./courseNew";
 export * from "./classNew";
 export * from "./grade-distribution";
+export * from "./enrollmentNew";


### PR DESCRIPTION
Queries the Classes SIS API for enrollment data on each section, and adds the data to the corresponding EnrollmentHistory document if and only if there is a change in the enrollment data. 

Uses Mongo transactions, thus requires a replica-set Mongo instance. 