### PR TITLE
(core) k8s read-only role for helm diffs

### DIFF
--- a/infra/base/templates/helm-diff-role.yaml
+++ b/infra/base/templates/helm-diff-role.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: helm-diff-sa
+  namespace: bt
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: helm-diff-role
+  namespace: bt
+rules:
+- apiGroups: [""]
+  resources: ["pods", "services", "configmaps", "secrets"]
+  verbs: ["get", "list"]
+- apiGroups: ["apps"]
+  resources: ["deployments", "statefulsets"]
+  verbs: ["get", "list"]
+- apiGroups: ["networking.k8s.io"]
+  resources: ["ingresses"]
+  verbs: ["get", "list"]

--- a/infra/base/templates/helm-diff-role.yaml
+++ b/infra/base/templates/helm-diff-role.yaml
@@ -20,3 +20,18 @@ rules:
 - apiGroups: ["networking.k8s.io"]
   resources: ["ingresses"]
   verbs: ["get", "list"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: helm-diff-rolebinding
+  namespace: bt
+subjects:
+- kind: ServiceAccount
+  name: helm-diff-sa
+  namespace: bt
+roleRef:
+  kind: Role
+  name: helm-diff-role
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
This PR improves the Helm diff workflow by introducing a dedicated read-only role for accessing the deployed state. Instead of retrieving the full kubeconfig, the workflow now operates with minimal required permissions, enhancing security while ensuring accurate comparisons between the local and deployed state.