### PR TITLE
enrollment schema modification

### DIFF
--- a/apps/datapuller/src/lib/enrollment.ts
+++ b/apps/datapuller/src/lib/enrollment.ts
@@ -8,13 +8,23 @@ import { filterSection } from "./sections";
 
 const formatEnrollmentSingular = (input: ClassSection, time: Date) => {
   const termId = input.class?.session?.term?.id;
+  const year = input.class?.session?.term?.name?.split(" ")[0];
+  const semester = input.class?.session?.term?.name?.split(" ")[1];
   const sessionId = input.class?.session?.id;
   const sectionId = input.id?.toString();
+  const subject = input.class?.course?.subjectArea?.code?.replaceAll(" ", "");
+  const courseNumber = input.class?.course?.catalogNumber?.formatted;
+  const sectionNumber = input.number;
 
   const essentialFields = {
     termId,
+    year,
+    semester,
     sessionId,
     sectionId,
+    subject,
+    courseNumber,
+    sectionNumber,
   };
 
   const missingField = Object.keys(essentialFields).find(
@@ -26,8 +36,14 @@ const formatEnrollmentSingular = (input: ClassSection, time: Date) => {
 
   const output: IEnrollmentSingularItem = {
     termId: termId!,
+    year: parseInt(year!),
+    semester: semester!,
     sessionId: sessionId!,
     sectionId: sectionId!,
+    subject: subject!,
+    courseNumber: courseNumber!,
+    sectionNumber: sectionNumber!,
+
     data: {
       time: time.toISOString(),
       status: input.enrollmentStatus?.status?.code,

--- a/apps/datapuller/src/pullers/enrollment.ts
+++ b/apps/datapuller/src/pullers/enrollment.ts
@@ -116,6 +116,34 @@ const updateEnrollmentHistories = async ({
           { session }
         ).lean();
 
+        // migration (02/20/2025): add missing identifier fields
+        if (
+          doc &&
+          (!doc.year ||
+            !doc.semester ||
+            !doc.subject ||
+            !doc.courseNumber ||
+            !doc.sectionNumber)
+        ) {
+          await NewEnrollmentHistoryModel.updateOne(
+            {
+              termId: enrollmentSingular.termId,
+              sessionId: enrollmentSingular.sessionId,
+              sectionId: enrollmentSingular.sectionId,
+            },
+            {
+              $set: {
+                year: enrollmentSingular.year,
+                semester: enrollmentSingular.semester,
+                subject: enrollmentSingular.subject,
+                courseNumber: enrollmentSingular.courseNumber,
+                sectionNumber: enrollmentSingular.sectionNumber,
+              },
+            },
+            { session }
+          );
+        }
+
         // skip if no change
         if (doc && doc.history.length > 0) {
           const lastHistory = doc.history[doc.history.length - 1];

--- a/packages/common/src/models/enrollment-history.ts
+++ b/packages/common/src/models/enrollment-history.ts
@@ -2,16 +2,14 @@ import { Document, Model, Schema, model } from "mongoose";
 
 export interface IEnrollmentHistoryItem {
   termId: string;
+  year: number;
+  semester: string;
   sessionId: string;
   sectionId: string;
+  subject: string;
+  courseNumber: string;
+  sectionNumber: string;
 
-  // maps number to requirementGroup.
-  // this assumes that these fields are constant over time.
-  seatReservationTypes?: {
-    number: number;
-    requirementGroup?: string;
-    fromDate: string;
-  }[];
   history: {
     time: string;
     status?: string;
@@ -30,6 +28,13 @@ export interface IEnrollmentHistoryItem {
       enrolledCount?: number;
     }[];
   }[];
+  // maps number to requirementGroup.
+  // this assumes that these fields are constant over time.
+  seatReservationTypes?: {
+    number: number;
+    requirementGroup?: string;
+    fromDate: string;
+  }[];
 }
 
 export interface IEnrollmentSingularItem
@@ -43,8 +48,14 @@ export interface IEnrollmentHistoryItemDocument
 
 const enrollmentHistorySchema = new Schema<IEnrollmentHistoryItem>({
   termId: { type: String, required: true },
+  year: { type: Number, required: true },
+  semester: { type: String, required: true },
   sessionId: { type: String, required: true },
   sectionId: { type: String, required: true },
+  subject: { type: String, required: true },
+  courseNumber: { type: String, required: true },
+  sectionNumber: { type: String, required: true },
+
   history: [
     {
       _id: false,
@@ -80,6 +91,17 @@ const enrollmentHistorySchema = new Schema<IEnrollmentHistoryItem>({
 });
 enrollmentHistorySchema.index(
   { termId: 1, sessionId: 1, sectionId: 1 },
+  { unique: true }
+);
+enrollmentHistorySchema.index(
+  {
+    year: 1,
+    semester: 1,
+    sessionId: 1,
+    subject: 1,
+    courseNumber: 1,
+    sectionNumber: 1,
+  },
   { unique: true }
 );
 

--- a/turbo.json
+++ b/turbo.json
@@ -16,7 +16,7 @@
     },
     "generate": {
       "outputs": [
-        "*/generated-types/**"
+        "*/**/generated-types/**"
       ]
     },
     "lint": {},


### PR DESCRIPTION
Add other identifying fields to enrollment histories to reduce queries between frontend/backend. Now, enrollment documents are unique with the compound index: 

```js
enrollmentHistorySchema.index(
  {
    year: 1,
    semester: 1,
    sessionId: 1,
    subject: 1,
    courseNumber: 1,
    sectionNumber: 1,
  },
  { unique: true }
);
```