### PR TITLE
complete modules rewrite

### DIFF
--- a/apps/backend/src/modules/class/controller.ts
+++ b/apps/backend/src/modules/class/controller.ts
@@ -24,8 +24,6 @@ export const getClass = async (
     number,
   }).lean();
 
-  console.log(sessionId);
-
   if (!_class) return null;
 
   return formatClass(_class as IClassItem);

--- a/apps/backend/src/modules/class/controller.ts
+++ b/apps/backend/src/modules/class/controller.ts
@@ -1,77 +1,97 @@
-import { ClassModel, ClassType, SectionModel, SectionType } from "@repo/common";
+import {
+  IClassItem,
+  ISectionItem,
+  NewClassModel,
+  NewSectionModel,
+} from "@repo/common";
 
 import { formatClass, formatSection } from "./formatter";
 
 export const getClass = async (
   year: number,
   semester: string,
+  sessionId: string,
   subject: string,
   courseNumber: string,
-  classNumber: string
+  number: string
 ) => {
-  const _class = await ClassModel.findOne({
-    "course.subjectArea.code": subject,
-    "course.catalogNumber.formatted": courseNumber,
-    "session.term.name": `${year} ${semester}`,
-    number: classNumber,
+  const _class = await NewClassModel.findOne({
+    year,
+    semester,
+    sessionId: sessionId ? sessionId : "1",
+    subject,
+    courseNumber,
+    number,
   }).lean();
+
+  console.log(sessionId);
 
   if (!_class) return null;
 
-  return formatClass(_class as ClassType);
+  return formatClass(_class as IClassItem);
 };
 
 export const getSecondarySections = async (
   year: number,
   semester: string,
+  sessionId: string,
   subject: string,
   courseNumber: string,
   number: string
 ) => {
-  const sections = await SectionModel.find({
-    "class.course.subjectArea.code": subject,
-    "class.course.catalogNumber.formatted": courseNumber,
-    "class.session.term.name": `${year} ${semester}`,
-    "class.number": { $regex: `^(${number[number.length - 1]}|999)` },
+  const sections = await NewSectionModel.find({
+    year,
+    semester,
+    sessionId: sessionId ? sessionId : "1",
+    subject,
+    courseNumber,
+    number: { $regex: `^(${number[number.length - 1]}|999)` },
   }).lean();
 
-  return sections.map((section) => formatSection(section as SectionType));
+  return sections.map((section) => formatSection(section as ISectionItem));
 };
 
 export const getPrimarySection = async (
   year: number,
   semester: string,
+  sessionId: string,
   subject: string,
   courseNumber: string,
-  classNumber: string
+  number: string
 ) => {
-  const section = await SectionModel.findOne({
-    "class.course.subjectArea.code": subject,
-    "class.course.catalogNumber.formatted": courseNumber,
-    "class.session.term.name": `${year} ${semester}`,
-    "class.number": classNumber,
+  const section = await NewSectionModel.findOne({
+    year,
+    semester,
+    sessionId: sessionId ? sessionId : "1",
+    subject,
+    courseNumber,
+    number,
+    primary: true,
   }).lean();
 
   if (!section) return null;
 
-  return formatSection(section as SectionType);
+  return formatSection(section as ISectionItem);
 };
 
 export const getSection = async (
   year: number,
   semester: string,
+  sessionId: string,
   subject: string,
   courseNumber: string,
   number: string
 ) => {
-  const section = await SectionModel.findOne({
-    "class.course.subjectArea.code": subject,
-    "class.course.catalogNumber.formatted": courseNumber,
-    "class.session.term.name": `${year} ${semester}`,
-    number: number,
+  const section = await NewSectionModel.findOne({
+    year,
+    semester,
+    sessionId: sessionId ? sessionId : "1",
+    subject,
+    courseNumber,
+    number,
   }).lean();
 
   if (!section) return null;
 
-  return formatSection(section as SectionType);
+  return formatSection(section as ISectionItem);
 };

--- a/apps/backend/src/modules/class/formatter.ts
+++ b/apps/backend/src/modules/class/formatter.ts
@@ -2,19 +2,19 @@ import { IClassItem, ISectionItem } from "@repo/common";
 
 import { ClassModule } from "./generated-types/module-types";
 
-const classRelationships = {
-  term: null,
-  course: null,
-  primarySection: null,
-  sections: null,
-  gradeDistribution: null,
-};
+interface ClassRelationships {
+  term: null;
+  course: null;
+  primarySection: null;
+  sections: null;
+  gradeDistribution: null;
+}
 
 export type IntermediateClass = Omit<
   ClassModule.Class,
-  keyof typeof classRelationships
+  keyof ClassRelationships
 > &
-  typeof classRelationships;
+  ClassRelationships;
 
 export const formatDate = (date?: string | number | Date | null) => {
   if (!date) return date;
@@ -27,16 +27,21 @@ export const formatDate = (date?: string | number | Date | null) => {
 export const formatClass = (_class: IClassItem) => {
   const output = {
     ..._class,
-    ...classRelationships,
 
     unitsMax: _class.allowedUnits?.maximum || 0,
     unitsMin: _class.allowedUnits?.minimum || 0,
+
+    term: null,
+    course: null,
+    primarySection: null,
+    sections: null,
+    gradeDistribution: null,
   } as IntermediateClass;
 
   return output;
 };
 
-export interface SectionRelationships {
+interface SectionRelationships {
   course: string;
 
   term: null;

--- a/apps/backend/src/modules/class/formatter.ts
+++ b/apps/backend/src/modules/class/formatter.ts
@@ -59,6 +59,7 @@ export const formatSection = (section: ISectionItem) => {
   const output = {
     ...section,
 
+    online: section.instructionMode === "O",
     course: section.courseId,
 
     term: null,

--- a/apps/backend/src/modules/class/formatter.ts
+++ b/apps/backend/src/modules/class/formatter.ts
@@ -1,25 +1,20 @@
-import { ClassType, SectionType } from "@repo/common";
+import { IClassItem, ISectionItem } from "@repo/common";
 
-import {
-  ClassFinalExam,
-  ClassGradingBasis,
-  Semester,
-} from "../../generated-types/graphql";
 import { ClassModule } from "./generated-types/module-types";
 
-export interface ClassRelationships {
-  course: null;
-  term: null;
-  primarySection: null;
-  sections: null;
-  gradeDistribution: null;
-}
+const classRelationships = {
+  term: null,
+  course: null,
+  primarySection: null,
+  sections: null,
+  gradeDistribution: null,
+};
 
 export type IntermediateClass = Omit<
   ClassModule.Class,
-  keyof ClassRelationships
+  keyof typeof classRelationships
 > &
-  ClassRelationships;
+  typeof classRelationships;
 
 export const formatDate = (date?: string | number | Date | null) => {
   if (!date) return date;
@@ -29,131 +24,42 @@ export const formatDate = (date?: string | number | Date | null) => {
   return new Date(date).toISOString();
 };
 
-export const formatClass = (_class: ClassType) => {
-  const [year, semester] = _class.session?.term?.name?.split(" ") as string[];
+export const formatClass = (_class: IClassItem) => {
+  const output = {
+    ..._class,
+    ...classRelationships,
 
-  return {
-    subject: _class.course?.subjectArea?.code as string,
-    courseNumber: _class.course?.catalogNumber?.formatted as string,
-    number: _class.number as string,
-
-    year: parseInt(year),
-    semester: semester as Semester,
-    session: _class.session?.id as string,
-
-    course: null,
-    gradeDistribution: null,
-    term: null,
-    primarySection: null,
-    sections: null,
-
-    description: _class.classDescription,
-    gradingBasis: _class.gradingBasis?.description as ClassGradingBasis,
-    finalExam: _class.finalExam?.code as ClassFinalExam,
-    title: _class.classTitle,
-    unitsMax: _class.allowedUnits?.maximum as number,
-    unitsMin: _class.allowedUnits?.minimum as number,
+    unitsMax: _class.allowedUnits?.maximum || 0,
+    unitsMin: _class.allowedUnits?.minimum || 0,
   } as IntermediateClass;
+
+  return output;
 };
+
+export interface SectionRelationships {
+  course: string;
+
+  term: null;
+  class: null;
+  enrollment: null;
+}
 
 export type IntermediateSection = Omit<
   ClassModule.Section,
-  "course" | "term" | "class"
-> & {
-  course: null;
-  term: null;
-  class: null;
-};
+  keyof SectionRelationships
+> &
+  SectionRelationships;
 
-export const formatSection = (section: SectionType) => {
-  const [year, semester] = section?.class?.session?.term?.name?.split(
-    " "
-  ) as string[];
+export const formatSection = (section: ISectionItem) => {
+  const output = {
+    ...section,
 
-  return {
-    subject: section.class?.course?.subjectArea?.code as string,
-    courseNumber: section?.class?.course?.catalogNumber?.formatted as string,
-    classNumber: section?.class?.number as string,
-    number: section.number as string,
+    course: section.courseId,
 
-    year: parseInt(year),
-    semester: semester as Semester,
-    session: section?.class?.session?.id as string,
-
-    class: null,
-    course: null,
     term: null,
-
-    ccn: section.id as number,
-    primary: section.association?.primary as boolean,
-
-    component: section.component?.code as string,
-
-    endDate: formatDate(section?.endDate),
-    startDate: formatDate(section?.startDate),
-
-    meetings: section.meetings?.map((m) => ({
-      days: [
-        m.meetsSunday,
-        m.meetsMonday,
-        m.meetsTuesday,
-        m.meetsWednesday,
-        m.meetsThursday,
-        m.meetsFriday,
-        m.meetsSaturday,
-      ],
-
-      endDate: formatDate(m.endDate),
-      endTime: m.endTime,
-      location: m.location?.description,
-      startDate: formatDate(m.startDate),
-      startTime: m.startTime,
-
-      instructors: m?.assignedInstructors
-        ?.filter(
-          (i) => i.printInScheduleOfClasses && i.instructor?.names != undefined
-        )
-        .map((i) => {
-          // Primary name has precedence over preferred name
-          let nameInfo = i.instructor?.names?.find(
-            (n) => n.type?.code === "PRI"
-          );
-          if (nameInfo == undefined) {
-            nameInfo = i.instructor?.names?.find((n) => n.type?.code === "PRF");
-          }
-
-          return {
-            givenName: nameInfo?.givenName as string,
-            familyName: nameInfo?.familyName as string,
-          };
-        }),
-    })),
-
-    exams: section.exams?.map((e) => ({
-      date: formatDate(e.date),
-      endTime: e.endTime,
-      location: e.location?.description as string,
-      startTime: e.startTime,
-
-      // FIN: Final, MID: Midterm
-      final: e.type?.code === "FIN",
-    })),
-
-    // P: In-Person Instruction, O: Online
-    online: section.instructionMode?.code === "O",
-
-    // O: Open, C: Closed
-    open: section.enrollmentStatus?.status?.code === "O",
-
-    enrollCount: section.enrollmentStatus?.enrolledCount as number,
-    enrollMax: section.enrollmentStatus?.maxEnroll as number,
-    waitlistCount: section.enrollmentStatus?.waitlistedCount as number,
-    waitlistMax: section.enrollmentStatus?.maxWaitlist as number,
-
-    reservations: section.enrollmentStatus?.seatReservations?.map((sr) => ({
-      group: sr.requirementGroup?.description as string,
-      enrollCount: sr.enrolledCount as number,
-      enrollMax: sr.maxEnroll as number,
-    })),
+    class: null,
+    enrollment: null,
   } as IntermediateSection;
+
+  return output;
 };

--- a/apps/backend/src/modules/class/resolver.ts
+++ b/apps/backend/src/modules/class/resolver.ts
@@ -2,8 +2,7 @@ import { GraphQLError, GraphQLScalarType, Kind } from "graphql";
 
 import { getCourse } from "../course/controller";
 import { CourseModule } from "../course/generated-types/module-types";
-import { getEnrollment } from "../enrollment/controller";
-import { EnrollmentModule } from "../enrollment/generated-types/module-types";
+import { getEnrollmentBySectionId } from "../enrollment/controller";
 import { getGradeDistributionByClass } from "../grade-distribution/controller";
 import { getTerm } from "../term/controller";
 import { TermModule } from "../term/generated-types/module-types";
@@ -195,22 +194,21 @@ const resolvers: ClassModule.Resolvers = {
     enrollment: async (parent: IntermediateSection | ClassModule.Section) => {
       if (parent.enrollment) return parent.enrollment;
 
-      const enrollmentHistory = await getEnrollment(
-        parent.year,
-        parent.semester,
+      const enrollmentHistory = await getEnrollmentBySectionId(
+        parent.termId,
         parent.sessionId,
-        parent.subject,
-        parent.courseNumber,
         parent.sectionId
       );
       const latestEnrollmentSingular =
-        enrollmentHistory.history[enrollmentHistory.history.length - 1];
+        enrollmentHistory?.history[enrollmentHistory?.history.length - 1];
 
-      return latestEnrollmentSingular as EnrollmentModule.EnrollmentSingular;
+      return {
+        latestEnrollment: latestEnrollmentSingular,
+        seatReservationTypes: enrollmentHistory?.seatReservationTypes,
+      } as ClassModule.LatestEnrollment;
     },
   },
 
-  // @ts-expect-error - Not sure how to type this
   // Session: {
   //   R: "1",
   //   S: "12W",
@@ -222,15 +220,15 @@ const resolvers: ClassModule.Resolvers = {
   //   F: "3W2",
   // },
 
-  ClassGradingBasis: {
-    ESU: "Elective Satisfactory/Unsat",
-    SUS: "Satisfactory/Unsatisfactory",
-    OPT: "Student Option",
-    PNP: "Pass/Not Pass",
-    BMT: "Multi-Term Course: Not Graded",
-    GRD: "Graded",
-    IOP: "Instructor Option",
-  },
+  // ClassGradingBasis: {
+  //   ESU: "Elective Satisfactory/Unsat",
+  //   SUS: "Satisfactory/Unsatisfactory",
+  //   OPT: "Student Option",
+  //   PNP: "Pass/Not Pass",
+  //   BMT: "Multi-Term Course: Not Graded",
+  //   GRD: "Graded",
+  //   IOP: "Instructor Option",
+  // },
 };
 
 export default resolvers;

--- a/apps/backend/src/modules/class/resolver.ts
+++ b/apps/backend/src/modules/class/resolver.ts
@@ -199,13 +199,8 @@ const resolvers: ClassModule.Resolvers = {
         parent.sessionId,
         parent.sectionId
       );
-      const latestEnrollmentSingular =
-        enrollmentHistory?.history[enrollmentHistory?.history.length - 1];
 
-      return {
-        latestEnrollment: latestEnrollmentSingular,
-        seatReservationTypes: enrollmentHistory?.seatReservationTypes,
-      } as ClassModule.LatestEnrollment;
+      return enrollmentHistory;
     },
   },
 

--- a/apps/backend/src/modules/class/typedefs/class.ts
+++ b/apps/backend/src/modules/class/typedefs/class.ts
@@ -102,7 +102,7 @@ export default gql`
     term: Term!
     course: Course!
     class: Class!
-    enrollment: LatestEnrollment!
+    enrollment: Enrollment
 
     "Attributes"
     year: Int!
@@ -119,11 +119,6 @@ export default gql`
     meetings: [Meeting!]!
     exams: [Exam!]!
     online: Boolean!
-  }
-
-  type LatestEnrollment {
-    latestEnrollment: EnrollmentSingular
-    seatReservationTypes: [SeatReservationType!]
   }
 
   enum Component {

--- a/apps/backend/src/modules/class/typedefs/class.ts
+++ b/apps/backend/src/modules/class/typedefs/class.ts
@@ -7,6 +7,7 @@ export default gql`
     class(
       year: Int!
       semester: Semester!
+      sessionId: SessionIdentifier
       subject: String!
       courseNumber: CourseNumber!
       number: ClassNumber!
@@ -14,30 +15,32 @@ export default gql`
     section(
       year: Int!
       semester: Semester!
+      sessionId: SessionIdentifier
       subject: String!
       courseNumber: CourseNumber!
-      classNumber: ClassNumber!
       number: SectionNumber!
     ): Section
   }
 
   type Class {
     "Identifiers"
+    termId: TermIdentifier!
+    sessionId: SessionIdentifier!
+    courseId: String!
+    number: ClassNumber!
     subject: String!
     courseNumber: CourseNumber!
-    number: ClassNumber!
-    year: Int!
-    semester: Semester!
-    session: String!
 
     "Relationships"
+    term: Term!
     course: Course!
     primarySection: Section!
     sections: [Section!]!
-    term: Term!
     gradeDistribution: GradeDistribution!
 
     "Attributes"
+    year: Int!
+    semester: Semester!
     gradingBasis: ClassGradingBasis!
     finalExam: ClassFinalExam!
     description: String
@@ -91,35 +94,30 @@ export default gql`
 
   type Section {
     "Identifiers"
+    termId: TermIdentifier!
+    sessionId: SessionIdentifier!
+    sectionId: SectionIdentifier!
+
+    "Relationships"
+    term: Term!
+    course: Course!
+    class: Class!
+    enrollment: EnrollmentSingular!
+
+    "Attributes"
+    year: Int!
+    semester: Semester!
     subject: String!
     courseNumber: CourseNumber!
     classNumber: ClassNumber!
     number: SectionNumber!
-    year: Int!
-    semester: Semester!
-    ccn: SectionIdentifier!
-
-    "Relationships"
-    class: Class!
-    course: Course!
-    term: Term!
-
-    "Attributes"
-    session: String!
+    startDate: String!
+    endDate: String!
     primary: Boolean!
-    enrollmentHistory: [EnrollmentDay!]
+    instructionMode: String!
     component: Component!
     meetings: [Meeting!]!
     exams: [Exam!]!
-    startDate: String!
-    endDate: String!
-    online: Boolean!
-    open: Boolean!
-    reservations: [Reservation!]
-    enrollCount: Int!
-    waitlistCount: Int!
-    enrollMax: Int!
-    waitlistMax: Int!
   }
 
   enum Component {
@@ -214,7 +212,19 @@ export default gql`
     startTime: String!
     endTime: String!
     location: String!
-    final: Boolean!
+    type: ExamType!
+  }
+
+  enum ExamType {
+    "Final"
+    FIN
+
+    "Midterm"
+    MID
+
+    ALT
+
+    MAK
   }
 
   type Instructor {

--- a/apps/backend/src/modules/class/typedefs/class.ts
+++ b/apps/backend/src/modules/class/typedefs/class.ts
@@ -27,9 +27,9 @@ export default gql`
     termId: TermIdentifier!
     sessionId: SessionIdentifier!
     courseId: String!
-    number: ClassNumber!
     subject: String!
     courseNumber: CourseNumber!
+    number: ClassNumber!
 
     "Relationships"
     term: Term!
@@ -102,7 +102,7 @@ export default gql`
     term: Term!
     course: Course!
     class: Class!
-    enrollment: EnrollmentSingular!
+    enrollment: LatestEnrollment!
 
     "Attributes"
     year: Int!
@@ -118,6 +118,12 @@ export default gql`
     component: Component!
     meetings: [Meeting!]!
     exams: [Exam!]!
+    online: Boolean!
+  }
+
+  type LatestEnrollment {
+    latestEnrollment: EnrollmentSingular
+    seatReservationTypes: [SeatReservationType!]
   }
 
   enum Component {

--- a/apps/backend/src/modules/course/formatter.ts
+++ b/apps/backend/src/modules/course/formatter.ts
@@ -2,7 +2,7 @@ import { ICourseItem } from "@repo/common";
 
 import { CourseModule } from "./generated-types/module-types";
 
-export interface CourseRelationships {
+interface CourseRelationships {
   classes: null;
   gradeDistribution: null;
   crossListing: string[];

--- a/apps/backend/src/modules/course/formatter.ts
+++ b/apps/backend/src/modules/course/formatter.ts
@@ -18,6 +18,8 @@ export type IntermediateCourse = Omit<
 export function formatCourse(course: ICourseItem) {
   const output = {
     ...course,
+    gradingBasis: course.gradingBasis as CourseModule.CourseGradingBasis,
+    finalExam: course.finalExam as CourseModule.CourseFinalExam,
 
     classes: null,
     gradeDistribution: null,

--- a/apps/backend/src/modules/course/formatter.ts
+++ b/apps/backend/src/modules/course/formatter.ts
@@ -1,19 +1,12 @@
-import { CourseType } from "@repo/common";
+import { ICourseItem } from "@repo/common";
 
-import {
-  AcademicCareer,
-  CourseFinalExam,
-  CourseGradingBasis,
-  InstructionMethod,
-} from "../../generated-types/graphql";
-import { formatDate } from "../class/formatter";
 import { CourseModule } from "./generated-types/module-types";
 
 export interface CourseRelationships {
   classes: null;
+  gradeDistribution: null;
   crossListing: string[];
   requiredCourses: string[];
-  gradeDistribution: null;
 }
 
 export type IntermediateCourse = Omit<
@@ -22,37 +15,15 @@ export type IntermediateCourse = Omit<
 > &
   CourseRelationships;
 
-export function formatCourse(course: CourseType) {
-  return {
-    subject: course.subjectArea?.code as string,
-    number: course.catalogNumber?.formatted as string,
+export function formatCourse(course: ICourseItem) {
+  const output = {
+    ...course,
 
-    gradeDistribution: null,
     classes: null,
-    crossListing: course.crossListing?.courses ?? [],
-    requiredCourses:
-      course.preparation?.requiredCourses.map?.((course) => {
-        const split = course.displayName?.split(" ") as string[];
-
-        const subject = split.slice(0, -1).join(" ");
-        const number = split[split.length - 1];
-
-        return `${subject} ${number}`;
-      }) ?? [],
-
-    requirements: course.preparation?.requiredText,
-    description: course.description as string,
-    primaryInstructionMethod: course.primaryInstructionMethod
-      ?.code as InstructionMethod,
-    fromDate: formatDate(course.fromDate),
-    finalExam: course.finalExam?.description as CourseFinalExam,
-    gradingBasis: course.gradingBasis?.description as CourseGradingBasis,
-    academicCareer: course.academicCareer?.code as AcademicCareer,
-    title: course.title as string,
-    toDate: formatDate(course.toDate),
-    typicallyOffered:
-      // @ts-expect-error - The model was typed incorrectly
-      course.formatsOffered?.typicallyOffered?.terms?.termNames ??
-      course.formatsOffered?.typicallyOffered?.terms,
+    gradeDistribution: null,
+    crossListing: course.crossListing ?? [],
+    requiredCourses: course.preparation?.requiredCourses ?? [],
   } as IntermediateCourse;
+
+  return output;
 }

--- a/apps/backend/src/modules/course/resolver.ts
+++ b/apps/backend/src/modules/course/resolver.ts
@@ -131,15 +131,15 @@ const resolvers: CourseModule.Resolvers = {
     Y: "Written final exam conducted during the scheduled final exam period",
   },
 
-  ClassGradingBasis: {
-    ESU: "Elective Satisfactory/Unsat",
-    SUS: "Satisfactory/Unsatisfactory",
-    OPT: "Student Option",
-    PNP: "Pass/Not Pass",
-    BMT: "Multi-Term Course: Not Graded",
-    GRD: "Graded",
-    IOP: "Instructor Option",
-  },
+  // ClassGradingBasis: {
+  //   ESU: "Elective Satisfactory/Unsat",
+  //   SUS: "Satisfactory/Unsatisfactory",
+  //   OPT: "Student Option",
+  //   PNP: "Pass/Not Pass",
+  //   BMT: "Multi-Term Course: Not Graded",
+  //   GRD: "Graded",
+  //   IOP: "Instructor Option",
+  // },
 };
 
 export default resolvers;

--- a/apps/backend/src/modules/course/resolver.ts
+++ b/apps/backend/src/modules/course/resolver.ts
@@ -2,7 +2,8 @@ import { GraphQLError, GraphQLScalarType, Kind } from "graphql";
 
 import { getGradeDistributionByCourse } from "../grade-distribution/controller";
 import {
-  getAssociatedCourses,
+  getAssociatedCoursesById,
+  getAssociatedCoursesBySubjectNumber,
   getClassesByCourse,
   getCourse,
   getCourses,
@@ -11,6 +12,20 @@ import { IntermediateCourse } from "./formatter";
 import { CourseModule } from "./generated-types/module-types";
 
 const resolvers: CourseModule.Resolvers = {
+  CourseIdentifier: new GraphQLScalarType({
+    name: "CourseIdentifier",
+    parseValue: (value) => value,
+    serialize: (value) => value,
+    description: "Unique course identifier, such as 148047",
+    parseLiteral(ast) {
+      if (ast.kind === Kind.STRING) return ast.value;
+
+      throw new GraphQLError("Provided value is not a course identifier", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    },
+  }),
+
   CourseNumber: new GraphQLScalarType({
     name: "CourseNumber",
     parseValue: (value) => value,
@@ -43,19 +58,21 @@ const resolvers: CourseModule.Resolvers = {
     classes: async (parent: IntermediateCourse | CourseModule.Course) => {
       if (parent.classes) return parent.classes;
 
-      const classes = await getClassesByCourse(parent.subject, parent.number);
+      const classes = await getClassesByCourse(parent.courseId);
 
       return classes as unknown as CourseModule.Class[];
     },
 
     crossListing: async (parent: IntermediateCourse | CourseModule.Course) => {
+      // cross listings are stored as `${subject} ${number}`
+
       if (
         parent.crossListing.length === 0 ||
         typeof parent.crossListing[0] !== "string"
       )
         return parent.crossListing as CourseModule.Course[];
 
-      const associatedCourses = await getAssociatedCourses(
+      const associatedCourses = await getAssociatedCoursesBySubjectNumber(
         parent.crossListing as string[]
       );
 
@@ -65,13 +82,15 @@ const resolvers: CourseModule.Resolvers = {
     requiredCourses: async (
       parent: IntermediateCourse | CourseModule.Course
     ) => {
+      // required courses are stored as courseIds
+
       if (
         parent.requiredCourses.length === 0 ||
         typeof parent.requiredCourses[0] !== "string"
       )
         return parent.requiredCourses as CourseModule.Course[];
 
-      const associatedCourses = await getAssociatedCourses(
+      const associatedCourses = await getAssociatedCoursesById(
         parent.requiredCourses as string[]
       );
 

--- a/apps/backend/src/modules/course/typedefs/course.ts
+++ b/apps/backend/src/modules/course/typedefs/course.ts
@@ -1,6 +1,7 @@
 import { gql } from "graphql-tag";
 
 export default gql`
+  scalar CourseIdentifier
   scalar CourseNumber
 
   type Query {
@@ -10,6 +11,7 @@ export default gql`
 
   type Course {
     "Identifiers"
+    courseId: CourseIdentifier!
     subject: String!
     number: CourseNumber!
 
@@ -17,12 +19,12 @@ export default gql`
     classes: [Class!]!
     crossListing: [Course!]!
     requiredCourses: [Course!]!
+    gradeDistribution: GradeDistribution!
 
     "Attributes"
     requirements: String
     description: String!
     fromDate: String!
-    gradeDistribution: GradeDistribution!
     gradingBasis: CourseGradingBasis!
     finalExam: CourseFinalExam
     academicCareer: AcademicCareer!

--- a/apps/backend/src/modules/enrollment/controller.ts
+++ b/apps/backend/src/modules/enrollment/controller.ts
@@ -19,5 +19,23 @@ export const getEnrollment = async (
     sectionNumber,
   }).lean();
 
+  if (!enrollment) return null;
+
+  return enrollment as EnrollmentModule.Enrollment;
+};
+
+export const getEnrollmentBySectionId = async (
+  termId: string,
+  sessionId: string,
+  sectionId: string
+) => {
+  const enrollment = await NewEnrollmentHistoryModel.findOne({
+    termId,
+    sessionId,
+    sectionId,
+  }).lean();
+
+  if (!enrollment) return null;
+
   return enrollment as EnrollmentModule.Enrollment;
 };

--- a/apps/backend/src/modules/enrollment/controller.ts
+++ b/apps/backend/src/modules/enrollment/controller.ts
@@ -1,6 +1,6 @@
 import { NewEnrollmentHistoryModel } from "@repo/common";
 
-import { EnrollmentModule } from "./generated-types/module-types";
+import { formatEnrollment } from "./formatter";
 
 export const getEnrollment = async (
   year: number,
@@ -21,7 +21,7 @@ export const getEnrollment = async (
 
   if (!enrollment) return null;
 
-  return enrollment as EnrollmentModule.Enrollment;
+  return formatEnrollment(enrollment);
 };
 
 export const getEnrollmentBySectionId = async (
@@ -37,5 +37,5 @@ export const getEnrollmentBySectionId = async (
 
   if (!enrollment) return null;
 
-  return enrollment as EnrollmentModule.Enrollment;
+  return formatEnrollment(enrollment);
 };

--- a/apps/backend/src/modules/enrollment/controller.ts
+++ b/apps/backend/src/modules/enrollment/controller.ts
@@ -3,14 +3,20 @@ import { NewEnrollmentHistoryModel } from "@repo/common";
 import { EnrollmentModule } from "./generated-types/module-types";
 
 export const getEnrollment = async (
-  termId: string,
-  sessionId: string,
-  sectionId: string
+  year: number,
+  semester: string,
+  sessionId: string | null,
+  subject: string,
+  courseNumber: string,
+  sectionNumber: string
 ) => {
   const enrollment = await NewEnrollmentHistoryModel.findOne({
-    termId,
-    sessionId,
-    sectionId,
+    year,
+    semester,
+    sessionId: sessionId ? sessionId : "1",
+    subject,
+    courseNumber,
+    sectionNumber,
   }).lean();
 
   return enrollment as EnrollmentModule.Enrollment;

--- a/apps/backend/src/modules/enrollment/formatter.ts
+++ b/apps/backend/src/modules/enrollment/formatter.ts
@@ -1,0 +1,16 @@
+import { IEnrollmentHistoryItem } from "@repo/common";
+
+import { EnrollmentModule } from "./generated-types/module-types";
+
+export const formatEnrollment = (enrollment: IEnrollmentHistoryItem) => {
+  const output = {
+    ...enrollment,
+
+    latest:
+      enrollment.history.length > 0
+        ? enrollment.history[enrollment.history.length - 1]
+        : null,
+  } as EnrollmentModule.Enrollment;
+
+  return output;
+};

--- a/apps/backend/src/modules/enrollment/resolver.ts
+++ b/apps/backend/src/modules/enrollment/resolver.ts
@@ -3,8 +3,19 @@ import { EnrollmentModule } from "./generated-types/module-types";
 
 const resolvers: EnrollmentModule.Resolvers = {
   Query: {
-    enrollment: async (_, { termId, sessionId, sectionId }) =>
-      getEnrollment(termId, sessionId, sectionId),
+    enrollment: async (
+      _,
+      { year, semester, sessionId, subject, courseNumber, sectionNumber }
+    ) => {
+      return await getEnrollment(
+        year,
+        semester,
+        sessionId,
+        subject,
+        courseNumber,
+        sectionNumber
+      );
+    },
   },
 };
 

--- a/apps/backend/src/modules/enrollment/typedefs/enrollment.ts
+++ b/apps/backend/src/modules/enrollment/typedefs/enrollment.ts
@@ -1,27 +1,26 @@
 import { gql } from "graphql-tag";
 
 export default gql`
-  scalar TermId
-  scalar SessionId
-  scalar SectionId
-
   type Query {
     enrollment(
-      termId: TermId!
-      sessionId: SessionId!
-      sectionId: SectionId!
+      year: Int!
+      semester: Semester!
+      sessionId: SessionIdentifier
+      subject: String!
+      courseNumber: CourseNumber!
+      sectionNumber: SectionNumber!
     ): Enrollment!
   }
 
   type Enrollment {
     "Identifiers"
-    termId: TermId!
-    sessionId: SessionId!
-    sectionId: SectionId!
+    termId: TermIdentifier!
+    sessionId: SessionIdentifier!
+    sectionId: SectionIdentifier!
 
     "Attributes"
     seatReservationTypes: [SeatReservationType!]!
-    history: [EnrollmentHistory!]!
+    history: [EnrollmentSingular!]!
   }
 
   type SeatReservationType {
@@ -30,9 +29,9 @@ export default gql`
     fromDate: String!
   }
 
-  type EnrollmentHistory {
+  type EnrollmentSingular {
     time: String!
-    status: String!
+    status: EnrollmentStatus!
     enrolledCount: Int!
     reservedCount: Int!
     waitlistedCount: Int!
@@ -43,6 +42,14 @@ export default gql`
     instructorAddConsentRequired: Boolean
     instructorDropConsentRequired: Boolean
     seatReservationCounts: [SeatReservationCount!]!
+  }
+
+  enum EnrollmentStatus {
+    "Closed"
+    C
+
+    "Open"
+    O
   }
 
   type SeatReservationCount {

--- a/apps/backend/src/modules/enrollment/typedefs/enrollment.ts
+++ b/apps/backend/src/modules/enrollment/typedefs/enrollment.ts
@@ -26,6 +26,7 @@ export default gql`
     "Attributes"
     seatReservationTypes: [SeatReservationType!]!
     history: [EnrollmentSingular!]!
+    latest: EnrollmentSingular
   }
 
   type SeatReservationType {

--- a/apps/backend/src/modules/enrollment/typedefs/enrollment.ts
+++ b/apps/backend/src/modules/enrollment/typedefs/enrollment.ts
@@ -9,14 +9,19 @@ export default gql`
       subject: String!
       courseNumber: CourseNumber!
       sectionNumber: SectionNumber!
-    ): Enrollment!
+    ): Enrollment
   }
 
   type Enrollment {
     "Identifiers"
     termId: TermIdentifier!
+    year: Int!
+    semester: Semester!
     sessionId: SessionIdentifier!
     sectionId: SectionIdentifier!
+    subject: String!
+    courseNumber: CourseNumber!
+    sectionNumber: SectionNumber!
 
     "Attributes"
     seatReservationTypes: [SeatReservationType!]!

--- a/apps/backend/src/modules/grade-distribution/controller.ts
+++ b/apps/backend/src/modules/grade-distribution/controller.ts
@@ -1,11 +1,8 @@
 import {
   GradeDistributionModel,
   IGradeDistributionItem,
-  SectionModel,
-  TermModel,
+  NewSectionModel,
 } from "@repo/common";
-
-import { Semester } from "../../generated-types/graphql";
 
 enum Letter {
   APlus = "A+",
@@ -171,8 +168,8 @@ export const getGradeDistributionByCourse = async (
   number: string
 ) => {
   const distributions = await GradeDistributionModel.find({
-    courseNumber: number,
     subject,
+    courseNumber: number,
   });
 
   // if (distributions.length === 0)
@@ -187,28 +184,31 @@ export const getGradeDistributionByCourse = async (
 };
 
 export const getGradeDistributionByClass = async (
+  year: number,
+  semester: string,
+  sessionId: string,
   subject: string,
   courseNumber: string,
-  number: string,
-  year: number,
-  semester: Semester
+  sectionNumber: string
 ) => {
-  const name = `${year} ${semester}`;
-
-  const section = await SectionModel.findOne({
-    "class.course.subjectArea.code": subject,
-    "class.course.catalogNumber.formatted": courseNumber,
-    "class.session.term.name": name,
-    number,
-    "association.primary": true,
-  });
+  const section = await NewSectionModel.findOne({
+    year,
+    semester,
+    sessionId: sessionId ? sessionId : "1",
+    subject,
+    courseNumber,
+    number: sectionNumber,
+    primary: true,
+  })
+    .select({ sectionId: 1 })
+    .lean();
 
   if (!section) throw new Error("Class not found");
 
   const distributions = await GradeDistributionModel.find({
-    courseNumber,
     subject,
-    classNumber: section.id,
+    courseNumber,
+    sectionId: section.sectionId,
   });
 
   // if (distributions.length === 0)
@@ -223,20 +223,18 @@ export const getGradeDistributionByClass = async (
 };
 
 export const getGradeDistributionBySemester = async (
-  subject: string,
-  number: string,
   year: number,
-  semester: Semester
+  semester: string,
+  sessionId: string,
+  subject: string,
+  courseNumber: string
 ) => {
-  const name = `${year} ${semester}`;
-  const term = await TermModel.findOne({ name }).lean();
-
-  if (!term) throw new Error("Term not found");
-
   const distributions = await GradeDistributionModel.find({
-    courseNumber: number,
+    year,
+    semester,
+    sessionId: sessionId ? sessionId : "1",
     subject,
-    termId: term.id,
+    courseNumber,
   });
 
   // if (distributions.length === 0)
@@ -252,22 +250,25 @@ export const getGradeDistributionBySemester = async (
 
 export const getGradeDistributionByInstructor = async (
   subject: string,
-  number: string,
+  courseNumber: string,
   familyName: string,
   givenName: string
 ) => {
-  const sections = await SectionModel.find({
-    "meetings.assignedInstructors.instructor.names.familyName": familyName,
-    "meetings.assignedInstructors.instructor.names.givenName": givenName,
-    "class.course.subjectArea.code": subject,
-    "class.course.catalogNumber.formatted": number,
-    "association.primary": true,
-  });
+  const sections = await NewSectionModel.find({
+    subject,
+    courseNumber,
+    "meetings.instructors.familyName": familyName,
+    "meetings.instructors.givenName": givenName,
+    primary: true,
+  })
+    .select({ sectionId: 1 })
+    .lean();
 
   if (sections.length === 0) throw new Error("No classes found");
 
+  const sectionIds = sections.map((section) => section.sectionId);
   const distributions = await GradeDistributionModel.find({
-    classNumber: { $in: sections.map((section) => section.id) },
+    sectionId: { $in: sectionIds },
   });
 
   // if (distributions.length === 0)
@@ -282,28 +283,32 @@ export const getGradeDistributionByInstructor = async (
 };
 
 export const getGradeDistributionByInstructorAndSemester = async (
-  subject: string,
-  number: string,
   year: number,
-  semester: Semester,
-  givenName: string,
-  familyName: string
+  semester: string,
+  sessionId: string,
+  subject: string,
+  courseNumber: string,
+  familyName: string,
+  givenName: string
 ) => {
-  const name = `${year} ${semester}`;
-
-  const sections = await SectionModel.find({
-    "meetings.assignedInstructors.instructor.names.familyName": familyName,
-    "meetings.assignedInstructors.instructor.names.givenName": givenName,
-    "class.course.subjectArea.code": subject,
-    "class.course.catalogNumber.formatted": number,
-    "association.primary": true,
-    "class.session.term.name": name,
-  });
+  const sections = await NewSectionModel.find({
+    year,
+    semester,
+    sessionId: sessionId ? sessionId : "1",
+    subject,
+    courseNumber,
+    "meetings.instructors.familyName": familyName,
+    "meetings.instructors.givenName": givenName,
+    primary: true,
+  })
+    .select({ sectionId: 1 })
+    .lean();
 
   if (sections.length === 0) throw new Error("No classes found");
 
+  const sectionIds = sections.map((section) => section.sectionId);
   const distributions = await GradeDistributionModel.find({
-    classNumber: { $in: sections.map((section) => section.id) },
+    sectionId: { $in: sectionIds },
   });
 
   // if (distributions.length === 0)

--- a/apps/backend/src/modules/grade-distribution/resolver.ts
+++ b/apps/backend/src/modules/grade-distribution/resolver.ts
@@ -12,33 +12,36 @@ const resolvers: GradeDistributionModule.Resolvers = {
     grade: async (
       _,
       {
+        year,
+        semester,
+        sessionId,
         subject,
         courseNumber,
         classNumber,
-        year,
-        semester,
-        givenName,
         familyName,
+        givenName,
       }
     ) => {
-      if (year && semester && givenName && familyName) {
+      if (year && semester && sessionId && givenName && familyName) {
         return await getGradeDistributionByInstructorAndSemester(
-          subject,
-          courseNumber,
           year,
           semester,
-          givenName,
-          familyName
+          sessionId,
+          subject,
+          courseNumber,
+          familyName,
+          givenName
         );
       }
 
-      if (year && semester && classNumber) {
+      if (year && semester && sessionId && classNumber) {
         return await getGradeDistributionByClass(
+          year,
+          semester,
+          sessionId,
           subject,
           courseNumber,
-          classNumber,
-          year,
-          semester
+          classNumber
         );
       }
 
@@ -51,12 +54,13 @@ const resolvers: GradeDistributionModule.Resolvers = {
         );
       }
 
-      if (year && semester) {
+      if (year && semester && sessionId) {
         return await getGradeDistributionBySemester(
-          subject,
-          courseNumber,
           year,
-          semester
+          semester,
+          sessionId,
+          subject,
+          courseNumber
         );
       }
 

--- a/apps/backend/src/modules/grade-distribution/typedefs/grade-distribution.ts
+++ b/apps/backend/src/modules/grade-distribution/typedefs/grade-distribution.ts
@@ -14,13 +14,14 @@ export default gql`
 
   type Query {
     grade(
+      year: Int
+      semester: Semester
+      sessionId: SessionIdentifier
       subject: String!
       courseNumber: CourseNumber!
       classNumber: ClassNumber
-      year: Int
-      semester: Semester
-      givenName: String
       familyName: String
+      givenName: String
     ): GradeDistribution!
   }
 `;

--- a/apps/backend/src/modules/schedule/controller.ts
+++ b/apps/backend/src/modules/schedule/controller.ts
@@ -126,10 +126,9 @@ export const getClasses = async (
     if (!_class) continue;
 
     const sections = await NewSectionModel.find({
-      year,
-      semester,
-      sessionId: sessionId ? sessionId : "1",
-      id: { $in: selectedClass.sectionIds },
+      termId: _class.termId,
+      sessionId: _class.sessionId,
+      sectionId: { $in: selectedClass.sectionIds },
     }).lean();
 
     classes.push({

--- a/apps/backend/src/modules/schedule/formatter.ts
+++ b/apps/backend/src/modules/schedule/formatter.ts
@@ -15,14 +15,8 @@ export type IntermediateSchedule = Omit<
 
 export const formatSchedule = async (schedule: ScheduleType) => {
   return {
-    _id: schedule._id as string,
-    name: schedule.name,
-    createdBy: schedule.createdBy,
-    public: schedule.public,
-    classes: schedule.classes,
-    year: schedule.year,
-    semester: schedule.semester,
+    ...schedule,
+
     term: null,
-    events: schedule.events,
   } as IntermediateSchedule;
 };

--- a/apps/backend/src/modules/schedule/resolver.ts
+++ b/apps/backend/src/modules/schedule/resolver.ts
@@ -1,5 +1,4 @@
-import { Semester } from "../../generated-types/graphql";
-import { getTermByYearSemester } from "../term/controller";
+import { getTerm } from "../term/controller";
 import { TermModule } from "../term/generated-types/module-types";
 import {
   createSchedule,
@@ -31,10 +30,7 @@ const resolvers: ScheduleModule.Resolvers = {
     term: async (parent: IntermediateSchedule | ScheduleModule.Schedule) => {
       if (parent.term) return parent.term;
 
-      const term = await getTermByYearSemester(
-        parent.year,
-        parent.semester as Semester
-      );
+      const term = await getTerm(parent.year, parent.semester);
 
       return term as unknown as TermModule.Term;
     },
@@ -48,7 +44,8 @@ const resolvers: ScheduleModule.Resolvers = {
 
       const classes = await getClasses(
         parent.year,
-        parent.semester as Semester,
+        parent.semester,
+        parent.sessionId,
         parent.classes as ScheduleModule.SelectedClassInput[]
       );
 

--- a/apps/backend/src/modules/schedule/typedefs/schedule.ts
+++ b/apps/backend/src/modules/schedule/typedefs/schedule.ts
@@ -60,7 +60,7 @@ const typedef = gql`
     name: String!
     year: Int!
     semester: Semester!
-    sessionId: SessionIdentifier
+    sessionId: SessionIdentifier!
     events: [EventInput!]
     classes: [SelectedClassInput!]
     public: Boolean

--- a/apps/backend/src/modules/schedule/typedefs/schedule.ts
+++ b/apps/backend/src/modules/schedule/typedefs/schedule.ts
@@ -3,7 +3,7 @@ import { gql } from "graphql-tag";
 const typedef = gql`
   type SelectedClass {
     class: Class!
-    selectedSections: [SectionIdentifier!]
+    selectedSections: [Section!]!
   }
 
   type Event {
@@ -19,9 +19,10 @@ const typedef = gql`
     _id: ID!
     name: String!
     createdBy: String!
+    term: Term!
     year: Int!
     semester: Semester!
-    term: Term!
+    sessionId: SessionIdentifier!
     public: Boolean!
     classes: [SelectedClass!]!
     events: [Event!]!
@@ -45,7 +46,7 @@ const typedef = gql`
     subject: String!
     courseNumber: CourseNumber!
     number: ClassNumber!
-    sections: [SectionIdentifier!]!
+    sectionIds: [SectionIdentifier!]!
   }
 
   input UpdateScheduleInput {
@@ -59,6 +60,7 @@ const typedef = gql`
     name: String!
     year: Int!
     semester: Semester!
+    sessionId: SessionIdentifier
     events: [EventInput!]
     classes: [SelectedClassInput!]
     public: Boolean

--- a/apps/backend/src/modules/term/controller.ts
+++ b/apps/backend/src/modules/term/controller.ts
@@ -1,4 +1,4 @@
-import { NewTermModel, TermModel } from "@repo/common";
+import { NewTermModel } from "@repo/common";
 
 import { TermModule } from "./generated-types/module-types";
 
@@ -25,28 +25,19 @@ export const getTerms = async () => {
   return terms as TermModule.Term[];
 };
 
-export const getTerm = async (id: string, academicCareerCode: string) => {
-  const term = await NewTermModel.findOne({ id, academicCareerCode })
+export const getTerm = async (
+  year: number,
+  semester: string,
+  academicCareerCode: string = "UGRD"
+) => {
+  const term = await NewTermModel.findOne({
+    name: `${year} ${semester}`,
+    academicCareerCode,
+  })
     .select(fields)
     .lean();
 
   if (!term) return null;
 
   return term as TermModule.Term;
-};
-
-/**
- * To be deprecated.
- */
-export const getTermByYearSemester = async (
-  academicYear: number,
-  semester: string
-) => {
-  const term = await TermModel.findOne({
-    name: `${academicYear} ${semester} `,
-  }).lean();
-
-  if (!term) return null;
-
-  return term;
 };

--- a/apps/backend/src/modules/term/controller.ts
+++ b/apps/backend/src/modules/term/controller.ts
@@ -1,6 +1,6 @@
 import { NewTermModel } from "@repo/common";
 
-import { TermModule } from "./generated-types/module-types";
+import { formatTerm } from "./formatter";
 
 // database schema fields to select on queries.
 const fields = {
@@ -22,7 +22,7 @@ const fields = {
 export const getTerms = async () => {
   const terms = await NewTermModel.find({}).select(fields).lean();
 
-  return terms as TermModule.Term[];
+  return terms.map(formatTerm);
 };
 
 export const getTerm = async (
@@ -39,5 +39,5 @@ export const getTerm = async (
 
   if (!term) return null;
 
-  return term as TermModule.Term;
+  return formatTerm(term);
 };

--- a/apps/backend/src/modules/term/formatter.ts
+++ b/apps/backend/src/modules/term/formatter.ts
@@ -1,0 +1,22 @@
+import { ISessionItem, ITermItem } from "@repo/common";
+
+import { TermModule } from "./generated-types/module-types";
+
+const formatSession = (session: ISessionItem) => {
+  return {
+    ...session,
+    startDate: session.beginDate,
+  } as TermModule.Session;
+};
+
+export const formatTerm = (term: ITermItem) => {
+  const [year, semester] = term.name.split(" ");
+
+  return {
+    ...term,
+    year: parseInt(year),
+    semester,
+    startDate: term.beginDate,
+    sessions: term.sessions?.map(formatSession),
+  } as TermModule.Term;
+};

--- a/apps/backend/src/modules/term/typedefs/term.ts
+++ b/apps/backend/src/modules/term/typedefs/term.ts
@@ -46,7 +46,7 @@ const typedef = gql`
     "Attributes"
     temporalPosition: TemporalPosition!
     name: String!
-    beginDate: String!
+    startDate: String!
     endDate: String!
   }
 
@@ -63,10 +63,11 @@ const typedef = gql`
 
     "Attributes"
     temporalPosition: TemporalPosition!
-    name: String!
-    beginDate: String!
+    year: Int!
+    semester: Semester!
+    startDate: String!
     endDate: String!
-    sessions: [Session!]!
+    sessions: [Session!]
   }
 
   type Query {

--- a/apps/backend/src/modules/user/controller.ts
+++ b/apps/backend/src/modules/user/controller.ts
@@ -1,8 +1,8 @@
 import {
-  ClassModel,
-  ClassType,
-  CourseModel,
-  CourseType,
+  IClassItem,
+  ICourseItem,
+  NewClassModel,
+  NewCourseModel,
   UserModel,
 } from "@repo/common";
 
@@ -42,16 +42,16 @@ export const getBookmarkedCourses = async (
   const courses = [];
 
   for (const bookmarkedCourse of bookmarkedCourses) {
-    const course = await CourseModel.findOne({
-      "subjectArea.code": bookmarkedCourse.subject,
-      "catalogNumber.formatted": bookmarkedCourse.number,
+    const course = await NewCourseModel.findOne({
+      subject: bookmarkedCourse.subject,
+      number: bookmarkedCourse.number,
     })
       .sort({ fromDate: -1 })
       .lean();
 
     if (!course) continue;
 
-    courses.push(course as CourseType);
+    courses.push(course as ICourseItem);
   }
 
   return courses.map(formatCourse);
@@ -63,16 +63,18 @@ export const getBookmarkedClasses = async (
   const classes = [];
 
   for (const bookmarkedClass of bookmarkedClasses) {
-    const _class = await ClassModel.findOne({
+    const _class = await NewClassModel.findOne({
+      year: bookmarkedClass.year,
+      semester: bookmarkedClass.semester,
+      sessionId: bookmarkedClass.sessionId ? bookmarkedClass.sessionId : "1",
+      subject: bookmarkedClass.subject,
+      courseNumber: bookmarkedClass.courseNumber,
       number: bookmarkedClass.number,
-      "course.subjectArea.code": bookmarkedClass.subject,
-      "course.catalogNumber.formatted": bookmarkedClass.courseNumber,
-      "session.term.name": `${bookmarkedClass.year} ${bookmarkedClass.semester}`,
     }).lean();
 
     if (!_class) continue;
 
-    classes.push(_class as ClassType);
+    classes.push(_class as IClassItem);
   }
 
   return classes.map(formatClass);

--- a/apps/backend/src/modules/user/formatter.ts
+++ b/apps/backend/src/modules/user/formatter.ts
@@ -2,7 +2,7 @@ import { UserType } from "@repo/common";
 
 import { UserModule } from "./generated-types/module-types";
 
-export interface UserRelationships {
+interface UserRelationships {
   bookmarkedCourses: UserModule.BookmarkedCourseInput[];
   bookmarkedClasses: UserModule.BookmarkedClassInput[];
 }

--- a/apps/backend/src/modules/user/typedefs/user.ts
+++ b/apps/backend/src/modules/user/typedefs/user.ts
@@ -20,6 +20,7 @@ const typedef = gql`
   input BookmarkedClassInput {
     year: Int!
     semester: Semester!
+    sessionId: SessionIdentifier
     subject: String!
     courseNumber: CourseNumber!
     number: ClassNumber!

--- a/apps/datapuller/src/lib/grade-distributions.ts
+++ b/apps/datapuller/src/lib/grade-distributions.ts
@@ -47,7 +47,7 @@ const formatDistribution = (distribution: GradeDistributionRow) => {
     termId: distribution.semester_year_term_cd,
     sessionId: distribution.session_code,
 
-    classNumber: distribution.class_number,
+    sectionId: distribution.class_number, // not sure why tf the api is like this
     sectionNumber: distribution.class_section_cd,
 
     count: parseInt(distribution.grade_count),

--- a/apps/datapuller/src/lib/sections.ts
+++ b/apps/datapuller/src/lib/sections.ts
@@ -69,22 +69,6 @@ const formatSection = (input: ClassSection) => {
     primary: input.association?.primary,
     type: input.type?.code,
     combinedSections: input.combination?.combinedSections,
-    enrollment: {
-      status: input.enrollmentStatus?.status?.code,
-      enrolledCount: input.enrollmentStatus?.enrolledCount,
-      minEnroll: input.enrollmentStatus?.minEnroll,
-      maxEnroll: input.enrollmentStatus?.maxEnroll,
-      waitlistedCount: input.enrollmentStatus?.waitlistedCount,
-      maxWaitlist: input.enrollmentStatus?.maxWaitlist,
-      reservations: input.enrollmentStatus?.seatReservations?.map(
-        (reservation) => ({
-          number: reservation.number,
-          requirementGroup: reservation.requirementGroup?.description,
-          maxEnroll: reservation.maxEnroll,
-          enrolledCount: reservation.enrolledCount,
-        })
-      ),
-    },
     exams: input.exams?.map((exam) => ({
       date: exam.date,
       startTime: exam.startTime,

--- a/apps/frontend/src/app/Schedule/Editor/Calendar/index.tsx
+++ b/apps/frontend/src/app/Schedule/Editor/Calendar/index.tsx
@@ -48,7 +48,7 @@ export default function Calendar({
           exams,
           subject,
           courseNumber: number,
-          ccn,
+          sectionId,
         } = section;
 
         for (const meeting of meetings) {
@@ -59,7 +59,7 @@ export default function Calendar({
             endDate,
             subject,
             number,
-            active: currentSection?.ccn === ccn,
+            active: currentSection?.sectionId === sectionId,
             days,
             startTime,
             endTime,
@@ -84,7 +84,7 @@ export default function Calendar({
             date,
             subject: subject,
             number: number,
-            active: currentSection?.ccn === ccn,
+            active: currentSection?.sectionId === sectionId,
             startTime,
             endTime,
             startDate,

--- a/apps/frontend/src/app/Schedule/Editor/SideBar/Class/Section/index.tsx
+++ b/apps/frontend/src/app/Schedule/Editor/SideBar/Class/Section/index.tsx
@@ -18,7 +18,7 @@ export default function Section({
   onSectionMouseOver,
   onSectionMouseOut,
   active,
-  ccn,
+  sectionId,
   number,
   meetings: [{ startTime, endTime, days }],
 }: SectionProps & ISection) {
@@ -27,14 +27,14 @@ export default function Section({
       className={classNames(styles.root, {
         [styles.active]: active,
       })}
-      key={ccn}
+      key={sectionId}
       onClick={() => onSectionSelect?.()}
       onMouseOver={() => onSectionMouseOver()}
       onMouseOut={() => onSectionMouseOut()}
     >
       <div className={styles.radioButton} />
       <p className={styles.title}>{number}</p>
-      <CCN ccn={ccn} tooltip={false} />
+      <CCN sectionId={sectionId} tooltip={false} />
       <Time
         endTime={endTime}
         startTime={startTime}

--- a/apps/frontend/src/app/Schedule/Editor/SideBar/Class/index.tsx
+++ b/apps/frontend/src/app/Schedule/Editor/SideBar/Class/index.tsx
@@ -75,10 +75,20 @@ export default function Class({
                 gradeDistribution={_class.course.gradeDistribution}
               /> */}
               <Capacity
-                enrollCount={_class.primarySection.enrollCount}
-                enrollMax={_class.primarySection.enrollMax}
-                waitlistCount={_class.primarySection.waitlistCount}
-                waitlistMax={_class.primarySection.waitlistMax}
+                enrolledCount={
+                  _class.primarySection.enrollment.latestEnrollment
+                    .enrolledCount
+                }
+                maxEnroll={
+                  _class.primarySection.enrollment.latestEnrollment.maxEnroll
+                }
+                waitlistedCount={
+                  _class.primarySection.enrollment.latestEnrollment
+                    .waitlistedCount
+                }
+                maxWaitlist={
+                  _class.primarySection.enrollment.latestEnrollment.maxWaitlist
+                }
               />
               <Units unitsMin={_class.unitsMin} unitsMax={_class.unitsMax} />
             </div>
@@ -119,7 +129,7 @@ export default function Class({
                 </div>
                 {groups[group]?.map((section) => {
                   const active = selectedSections.some(
-                    (selectedSection) => selectedSection === section.ccn
+                    (selectedSection) => selectedSection === section.sectionId
                   );
 
                   return (
@@ -143,7 +153,7 @@ export default function Class({
                         )
                       }
                       {...section}
-                      key={section.ccn}
+                      key={section.sectionId}
                     />
                   );
                 })}

--- a/apps/frontend/src/app/Schedule/Editor/SideBar/Class/index.tsx
+++ b/apps/frontend/src/app/Schedule/Editor/SideBar/Class/index.tsx
@@ -76,18 +76,14 @@ export default function Class({
               /> */}
               <Capacity
                 enrolledCount={
-                  _class.primarySection.enrollment.latestEnrollment
-                    .enrolledCount
+                  _class.primarySection.enrollment.latest.enrolledCount
                 }
-                maxEnroll={
-                  _class.primarySection.enrollment.latestEnrollment.maxEnroll
-                }
+                maxEnroll={_class.primarySection.enrollment.latest.maxEnroll}
                 waitlistedCount={
-                  _class.primarySection.enrollment.latestEnrollment
-                    .waitlistedCount
+                  _class.primarySection.enrollment.latest.waitlistedCount
                 }
                 maxWaitlist={
-                  _class.primarySection.enrollment.latestEnrollment.maxWaitlist
+                  _class.primarySection.enrollment.latest.maxWaitlist
                 }
               />
               <Units unitsMin={_class.unitsMin} unitsMax={_class.unitsMax} />

--- a/apps/frontend/src/app/Schedule/Editor/SideBar/index.tsx
+++ b/apps/frontend/src/app/Schedule/Editor/SideBar/index.tsx
@@ -109,7 +109,7 @@ export default function SideBar({
         {schedule.classes.map((selectedClass, index) => {
           return (
             <Class
-              key={selectedClass.class.primarySection.ccn}
+              key={selectedClass.class.primarySection.sectionId}
               {...selectedClass}
               expanded={expanded[index]}
               onExpandedChange={(expanded) => onExpandedChange(index, expanded)}

--- a/apps/frontend/src/app/Schedule/Editor/index.tsx
+++ b/apps/frontend/src/app/Schedule/Editor/index.tsx
@@ -75,7 +75,7 @@ export default function Editor() {
       const selectedSections = selectedClass.selectedSections.filter(
         (selectedSection) => {
           const currentSection = selectedClass.class.sections.find(
-            (section) => section.ccn === selectedSection
+            (section) => section.sectionId === selectedSection
           );
 
           return !currentSection || currentSection !== section;
@@ -83,7 +83,7 @@ export default function Editor() {
       );
 
       // Add the selected section
-      selectedClass.selectedSections = [...selectedSections, section.ccn];
+      selectedClass.selectedSections = [...selectedSections, section.sectionId];
 
       // Update the schedule
       updateSchedule(
@@ -157,7 +157,7 @@ export default function Editor() {
       );
 
       // Ignore selected sections
-      if (selectedSections.includes(section.ccn)) return;
+      if (selectedSections.includes(section.sectionId)) return;
 
       setCurrentSection(section);
     },
@@ -276,7 +276,7 @@ export default function Editor() {
 
       const _class = data.class;
 
-      const selectedSections = [_class.primarySection.ccn];
+      const selectedSections = [_class.primarySection.sectionId];
 
       const kinds = Array.from(
         new Set(_class.sections.map((section) => section.component))
@@ -288,7 +288,7 @@ export default function Editor() {
           .filter((section) => section.component === kind)
           .sort((a, b) => a.number.localeCompare(b.number))[0];
 
-        selectedSections.push(section.ccn);
+        selectedSections.push(section.sectionId);
       }
 
       _schedule.classes.push({

--- a/apps/frontend/src/app/Schedule/Week/index.tsx
+++ b/apps/frontend/src/app/Schedule/Week/index.tsx
@@ -22,7 +22,9 @@ const adjustAttachedEvents = (
 
     positions[id][1]++;
 
-    const section = relevantSections.find((section) => id === section.ccn);
+    const section = relevantSections.find(
+      (section) => id === section.sectionId
+    );
     if (!section) return;
 
     const top = getY(section.meetings[0].startTime);
@@ -121,7 +123,7 @@ export default function Week({
             );
           }
 
-          positions[section.ccn] = [
+          positions[section.sectionId] = [
             position,
             attachedSections.length === 0
               ? 1
@@ -129,17 +131,17 @@ export default function Week({
           ];
 
           for (let i = top; i < top + height; i++) {
-            minutes[i].push(section.ccn);
+            minutes[i].push(section.sectionId);
           }
         }
 
         return relevantSections.map((section) => {
-          const [position, columns] = positions[section.ccn];
+          const [position, columns] = positions[section.sectionId];
 
           return {
             ...section,
             position,
-            active: section.ccn !== currentSection?.ccn,
+            active: section.sectionId !== currentSection?.sectionId,
             columns,
           };
         });
@@ -212,7 +214,7 @@ export default function Week({
                 <div key={hour} className={styles.hour}></div>
               ))}
               {events.map((event) => (
-                <Event key={event.ccn} {...event} />
+                <Event key={event.sectionId} {...event} />
               ))}
               {y && <div className={styles.line} style={{ top: `${y}px` }} />}
             </div>

--- a/apps/frontend/src/app/Schedule/schedule.ts
+++ b/apps/frontend/src/app/Schedule/schedule.ts
@@ -22,10 +22,10 @@ export const getSelectedSections = (schedule?: ISchedule) => {
     schedule?.classes.flatMap(({ selectedSections, class: _class }) =>
       selectedSections.reduce((acc, section) => {
         const _section =
-          _class.primarySection.ccn === section
+          _class.primarySection.sectionId === section
             ? _class.primarySection
             : _class.sections.find(
-                (currentSection) => currentSection.ccn === section
+                (currentSection) => currentSection.sectionId === section
               );
 
         return _section ? [...acc, _section] : acc;

--- a/apps/frontend/src/components/CCN/index.tsx
+++ b/apps/frontend/src/components/CCN/index.tsx
@@ -6,11 +6,11 @@ import { ClipboardCheck, Hashtag, PasteClipboard } from "iconoir-react";
 import styles from "./CCN.module.scss";
 
 interface CCNProps {
-  ccn: string;
+  sectionId: string;
   tooltip?: false;
 }
 
-export default function CCN({ ccn, tooltip }: CCNProps) {
+export default function CCN({ sectionId, tooltip }: CCNProps) {
   const textRef = useRef<HTMLSpanElement>(null);
 
   const [over, setOver] = useState(false);
@@ -33,7 +33,7 @@ export default function CCN({ ccn, tooltip }: CCNProps) {
     selection?.removeAllRanges();
     selection?.addRange(range);
 
-    navigator.clipboard.writeText(ccn);
+    navigator.clipboard.writeText(sectionId);
 
     setCopied(true);
 
@@ -57,7 +57,7 @@ export default function CCN({ ccn, tooltip }: CCNProps) {
           ) : (
             <Hashtag />
           )}
-          <span ref={textRef}>{ccn}</span>
+          <span ref={textRef}>{sectionId}</span>
         </div>
       </Tooltip.Trigger>
       <Tooltip.Portal>

--- a/apps/frontend/src/components/Capacity/index.tsx
+++ b/apps/frontend/src/components/Capacity/index.tsx
@@ -16,26 +16,26 @@ const getColor = (count: number, capacity: number) => {
 };
 
 interface CapacityProps {
-  enrollCount: number;
-  enrollMax: number;
-  waitlistCount: number;
-  waitlistMax: number;
+  enrolledCount: number;
+  maxEnroll: number;
+  waitlistedCount: number;
+  maxWaitlist: number;
 }
 
 export default function Capacity({
-  enrollCount,
-  enrollMax,
-  waitlistCount,
-  waitlistMax,
+  enrolledCount,
+  maxEnroll,
+  waitlistedCount,
+  maxWaitlist,
 }: CapacityProps) {
   const color = useMemo(
-    () => getColor(enrollCount, enrollMax),
-    [enrollCount, enrollMax]
+    () => getColor(enrolledCount, maxEnroll),
+    [enrolledCount, maxEnroll]
   );
 
   const waitlistColor = useMemo(
-    () => getColor(waitlistCount, waitlistMax),
-    [waitlistCount, waitlistMax]
+    () => getColor(waitlistedCount, maxWaitlist),
+    [waitlistedCount, maxWaitlist]
   );
 
   return (
@@ -44,9 +44,9 @@ export default function Capacity({
         <div className={styles.trigger}>
           <User />
           <p className={styles.text}>
-            <span style={{ color }}>{enrollCount.toLocaleString()}</span>
+            <span style={{ color }}>{enrolledCount.toLocaleString()}</span>
             &nbsp;/&nbsp;
-            {enrollMax.toLocaleString()}
+            {maxEnroll.toLocaleString()}
           </p>
         </div>
       </Tooltip.Trigger>
@@ -62,17 +62,17 @@ export default function Capacity({
             <div className={styles.row}>
               <p className={styles.key}>Enrolled</p>
               <p>
-                <span style={{ color }}>{enrollCount.toLocaleString()}</span>
+                <span style={{ color }}>{enrolledCount.toLocaleString()}</span>
                 &nbsp;/&nbsp;
                 <span className={styles.value}>
-                  {enrollMax.toLocaleString()}
+                  {maxEnroll.toLocaleString()}
                 </span>
                 &nbsp;(
                 <span style={{ color }}>
-                  {enrollMax === 0
+                  {maxEnroll === 0
                     ? 0
                     : Math.round(
-                        (enrollCount / enrollMax) * 100
+                        (enrolledCount / maxEnroll) * 100
                       ).toLocaleString()}
                   %
                 </span>
@@ -84,16 +84,16 @@ export default function Capacity({
               <p className={styles.key}>Waitlisted</p>
               <p>
                 <span style={{ color: waitlistColor }}>
-                  {waitlistCount.toLocaleString()}
+                  {waitlistedCount.toLocaleString()}
                 </span>
                 &nbsp;/&nbsp;
-                {waitlistMax.toLocaleString()}
+                {maxWaitlist.toLocaleString()}
                 &nbsp;(
                 <span style={{ color: waitlistColor }}>
-                  {waitlistMax === 0
+                  {maxWaitlist === 0
                     ? 0
                     : Math.round(
-                        (waitlistCount / waitlistMax) * 100
+                        (waitlistedCount / maxWaitlist) * 100
                       ).toLocaleString()}
                   %
                 </span>

--- a/apps/frontend/src/components/Carousel/Class/index.tsx
+++ b/apps/frontend/src/components/Carousel/Class/index.tsx
@@ -57,10 +57,19 @@ export default function Class({
           <div className={styles.row}>
             <AverageGrade gradeDistribution={_class.gradeDistribution} />
             <Capacity
-              enrollCount={_class.primarySection.enrollCount}
-              enrollMax={_class.primarySection.enrollMax}
-              waitlistCount={_class.primarySection.waitlistCount}
-              waitlistMax={_class.primarySection.waitlistMax}
+              enrolledCount={
+                _class.primarySection.enrollment.latestEnrollment.enrolledCount
+              }
+              maxEnroll={
+                _class.primarySection.enrollment.latestEnrollment.maxEnroll
+              }
+              waitlistedCount={
+                _class.primarySection.enrollment.latestEnrollment
+                  .waitlistedCount
+              }
+              maxWaitlist={
+                _class.primarySection.enrollment.latestEnrollment.maxWaitlist
+              }
             />
             <Units unitsMin={_class.unitsMin} unitsMax={_class.unitsMax} />
           </div>

--- a/apps/frontend/src/components/Carousel/Class/index.tsx
+++ b/apps/frontend/src/components/Carousel/Class/index.tsx
@@ -58,18 +58,13 @@ export default function Class({
             <AverageGrade gradeDistribution={_class.gradeDistribution} />
             <Capacity
               enrolledCount={
-                _class.primarySection.enrollment.latestEnrollment.enrolledCount
+                _class.primarySection.enrollment.latest.enrolledCount
               }
-              maxEnroll={
-                _class.primarySection.enrollment.latestEnrollment.maxEnroll
-              }
+              maxEnroll={_class.primarySection.enrollment.latest.maxEnroll}
               waitlistedCount={
-                _class.primarySection.enrollment.latestEnrollment
-                  .waitlistedCount
+                _class.primarySection.enrollment.latest.waitlistedCount
               }
-              maxWaitlist={
-                _class.primarySection.enrollment.latestEnrollment.maxWaitlist
-              }
+              maxWaitlist={_class.primarySection.enrollment.latest.maxWaitlist}
             />
             <Units unitsMin={_class.unitsMin} unitsMax={_class.unitsMax} />
           </div>

--- a/apps/frontend/src/components/Class/Enrollment/index.tsx
+++ b/apps/frontend/src/components/Class/Enrollment/index.tsx
@@ -12,7 +12,8 @@ import {
 import useClass from "@/hooks/useClass";
 
 import styles from "./Enrollment.module.scss";
-import Reservations from "./Reservations";
+
+// import Reservations from "./Reservations";
 
 const series = [
   {
@@ -126,11 +127,11 @@ export default function Enrollment() {
           </LineChart>
         </ResponsiveContainer>
       </div>
-      <Reservations
-        enrollCount={_class.primarySection.enrollCount}
-        enrollMax={_class.primarySection.enrollMax}
-        reservations={_class.primarySection.reservations}
-      />
+      {/* <Reservations
+        enrolledCount={_class.primarySection.enrollment.latestEnrollment.enrolledCount}
+        maxEnroll={_class.primarySection.enrollment.latestEnrollment.maxEnroll}
+        reservations={_class.primarySection.enrollment.latestEnrollment.seatReservationCounts}
+      /> */}
     </div>
   );
 }

--- a/apps/frontend/src/components/Class/Enrollment/index.tsx
+++ b/apps/frontend/src/components/Class/Enrollment/index.tsx
@@ -128,9 +128,9 @@ export default function Enrollment() {
         </ResponsiveContainer>
       </div>
       {/* <Reservations
-        enrolledCount={_class.primarySection.enrollment.latestEnrollment.enrolledCount}
-        maxEnroll={_class.primarySection.enrollment.latestEnrollment.maxEnroll}
-        reservations={_class.primarySection.enrollment.latestEnrollment.seatReservationCounts}
+        enrolledCount={_class.primarySection.enrollment.latest.enrolledCount}
+        maxEnroll={_class.primarySection.enrollment.latest.maxEnroll}
+        reservations={_class.primarySection.enrollment.latest.seatReservationCounts}
       /> */}
     </div>
   );

--- a/apps/frontend/src/components/Class/Sections/index.tsx
+++ b/apps/frontend/src/components/Class/Sections/index.tsx
@@ -117,19 +117,25 @@ export default function Sections() {
         {Object.values(groups).map((sections) => (
           <div className={styles.group}>
             {sections.map((section) => (
-              <div className={styles.section} key={section.ccn}>
+              <div className={styles.section} key={section.sectionId}>
                 <div className={styles.header}>
                   <div className={styles.text}>
                     <p className={styles.heading}>
                       {componentMap[section.component]} {section.number}
                     </p>
-                    <CCN ccn={section.ccn} />
+                    <CCN sectionId={section.sectionId} />
                   </div>
                   <Capacity
-                    enrollCount={section.enrollCount}
-                    enrollMax={section.enrollMax}
-                    waitlistCount={section.waitlistCount}
-                    waitlistMax={section.waitlistMax}
+                    enrolledCount={
+                      section.enrollment.latestEnrollment.enrolledCount
+                    }
+                    maxEnroll={section.enrollment.latestEnrollment.maxEnroll}
+                    waitlistedCount={
+                      section.enrollment.latestEnrollment.waitlistedCount
+                    }
+                    maxWaitlist={
+                      section.enrollment.latestEnrollment.maxWaitlist
+                    }
                   />
                   <Tooltip content="Berkeley Academic Guide">
                     <a

--- a/apps/frontend/src/components/Class/Sections/index.tsx
+++ b/apps/frontend/src/components/Class/Sections/index.tsx
@@ -126,16 +126,10 @@ export default function Sections() {
                     <CCN sectionId={section.sectionId} />
                   </div>
                   <Capacity
-                    enrolledCount={
-                      section.enrollment.latestEnrollment.enrolledCount
-                    }
-                    maxEnroll={section.enrollment.latestEnrollment.maxEnroll}
-                    waitlistedCount={
-                      section.enrollment.latestEnrollment.waitlistedCount
-                    }
-                    maxWaitlist={
-                      section.enrollment.latestEnrollment.maxWaitlist
-                    }
+                    enrolledCount={section.enrollment.latest.enrolledCount}
+                    maxEnroll={section.enrollment.latest.maxEnroll}
+                    waitlistedCount={section.enrollment.latest.waitlistedCount}
+                    maxWaitlist={section.enrollment.latest.maxWaitlist}
                   />
                   <Tooltip content="Berkeley Academic Guide">
                     <a

--- a/apps/frontend/src/components/Class/index.tsx
+++ b/apps/frontend/src/components/Class/index.tsx
@@ -220,6 +220,7 @@ export default function Class({
           courseNumber: bookmarkedClass.courseNumber,
           year: bookmarkedClass.year,
           semester: bookmarkedClass.semester,
+          sessionId: bookmarkedClass.sessionId,
         })),
       },
       {
@@ -378,13 +379,22 @@ export default function Class({
           <div className={styles.group}>
             <AverageGrade gradeDistribution={_class.course.gradeDistribution} />
             <Capacity
-              enrollCount={_class.primarySection.enrollCount}
-              enrollMax={_class.primarySection.enrollMax}
-              waitlistCount={_class.primarySection.waitlistCount}
-              waitlistMax={_class.primarySection.waitlistMax}
+              enrolledCount={
+                _class.primarySection.enrollment.latestEnrollment.enrolledCount
+              }
+              maxEnroll={
+                _class.primarySection.enrollment.latestEnrollment.maxEnroll
+              }
+              waitlistedCount={
+                _class.primarySection.enrollment.latestEnrollment
+                  .waitlistedCount
+              }
+              maxWaitlist={
+                _class.primarySection.enrollment.latestEnrollment.maxWaitlist
+              }
             />
             <Units unitsMax={_class.unitsMax} unitsMin={_class.unitsMin} />
-            {_class && <CCN ccn={_class.primarySection.ccn} />}
+            {_class && <CCN sectionId={_class.primarySection.sectionId} />}
           </div>
           {dialog ? (
             <Tabs.List className={styles.menu} defaultValue="overview">

--- a/apps/frontend/src/components/Class/index.tsx
+++ b/apps/frontend/src/components/Class/index.tsx
@@ -380,18 +380,13 @@ export default function Class({
             <AverageGrade gradeDistribution={_class.course.gradeDistribution} />
             <Capacity
               enrolledCount={
-                _class.primarySection.enrollment.latestEnrollment.enrolledCount
+                _class.primarySection.enrollment.latest.enrolledCount
               }
-              maxEnroll={
-                _class.primarySection.enrollment.latestEnrollment.maxEnroll
-              }
+              maxEnroll={_class.primarySection.enrollment.latest.maxEnroll}
               waitlistedCount={
-                _class.primarySection.enrollment.latestEnrollment
-                  .waitlistedCount
+                _class.primarySection.enrollment.latest.waitlistedCount
               }
-              maxWaitlist={
-                _class.primarySection.enrollment.latestEnrollment.maxWaitlist
-              }
+              maxWaitlist={_class.primarySection.enrollment.latest.maxWaitlist}
             />
             <Units unitsMax={_class.unitsMax} unitsMin={_class.unitsMin} />
             {_class && <CCN sectionId={_class.primarySection.sectionId} />}

--- a/apps/frontend/src/components/ClassBrowser/Filters/index.tsx
+++ b/apps/frontend/src/components/ClassBrowser/Filters/index.tsx
@@ -217,8 +217,7 @@ export default function Filters() {
   const amountOpen = useMemo(
     () =>
       includedClasses.filter(
-        (_class) =>
-          _class.primarySection.enrollment.latestEnrollment.status === "O"
+        (_class) => _class.primarySection.enrollment.latest.status === "O"
       ).length,
     [includedClasses]
   );

--- a/apps/frontend/src/components/ClassBrowser/Filters/index.tsx
+++ b/apps/frontend/src/components/ClassBrowser/Filters/index.tsx
@@ -215,7 +215,11 @@ export default function Filters() {
   ]);
 
   const amountOpen = useMemo(
-    () => includedClasses.filter((_class) => _class.primarySection.open).length,
+    () =>
+      includedClasses.filter(
+        (_class) =>
+          _class.primarySection.enrollment.latestEnrollment.status === "O"
+      ).length,
     [includedClasses]
   );
 

--- a/apps/frontend/src/components/ClassBrowser/List/Class/index.tsx
+++ b/apps/frontend/src/components/ClassBrowser/List/Class/index.tsx
@@ -25,7 +25,16 @@ const Course = forwardRef<HTMLDivElement, ClassProps & IClass>(
       },
       title,
       number,
-      primarySection: { enrollCount, enrollMax, waitlistCount, waitlistMax },
+      primarySection: {
+        enrollment: {
+          latestEnrollment: {
+            enrolledCount,
+            maxEnroll,
+            waitlistedCount,
+            maxWaitlist,
+          },
+        },
+      },
       unitsMax,
       unitsMin,
       index,
@@ -48,10 +57,10 @@ const Course = forwardRef<HTMLDivElement, ClassProps & IClass>(
           <div className={styles.row}>
             <AverageGrade gradeDistribution={gradeDistribution} />
             <Capacity
-              enrollCount={enrollCount}
-              enrollMax={enrollMax}
-              waitlistCount={waitlistCount}
-              waitlistMax={waitlistMax}
+              enrolledCount={enrolledCount}
+              maxEnroll={maxEnroll}
+              waitlistedCount={waitlistedCount}
+              maxWaitlist={maxWaitlist}
             />
             <Units unitsMin={unitsMin} unitsMax={unitsMax} />
           </div>

--- a/apps/frontend/src/components/ClassBrowser/List/Class/index.tsx
+++ b/apps/frontend/src/components/ClassBrowser/List/Class/index.tsx
@@ -27,12 +27,7 @@ const Course = forwardRef<HTMLDivElement, ClassProps & IClass>(
       number,
       primarySection: {
         enrollment: {
-          latestEnrollment: {
-            enrolledCount,
-            maxEnroll,
-            waitlistedCount,
-            maxWaitlist,
-          },
+          latest: { enrolledCount, maxEnroll, waitlistedCount, maxWaitlist },
         },
       },
       unitsMax,

--- a/apps/frontend/src/components/ClassBrowser/browser.ts
+++ b/apps/frontend/src/components/ClassBrowser/browser.ts
@@ -59,7 +59,7 @@ export const getFilteredClasses = (
       // Filter by open
       if (
         currentOpen &&
-        _class.primarySection.enrollment.latestEnrollment.status !== "O"
+        _class.primarySection.enrollment.latest.status !== "O"
       ) {
         acc.excludedClasses.push(_class);
 

--- a/apps/frontend/src/components/ClassBrowser/browser.ts
+++ b/apps/frontend/src/components/ClassBrowser/browser.ts
@@ -57,7 +57,10 @@ export const getFilteredClasses = (
   return classes.reduce(
     (acc, _class) => {
       // Filter by open
-      if (currentOpen && !_class.primarySection.open) {
+      if (
+        currentOpen &&
+        _class.primarySection.enrollment.latestEnrollment.status !== "O"
+      ) {
         acc.excludedClasses.push(_class);
 
         return acc;

--- a/apps/frontend/src/components/ClassBrowser/index.tsx
+++ b/apps/frontend/src/components/ClassBrowser/index.tsx
@@ -185,7 +185,7 @@ export default function ClassBrowser({
           const getOpenSeats = ({
             primarySection: {
               enrollment: {
-                latestEnrollment: { enrolledCount, maxEnroll },
+                latest: { enrolledCount, maxEnroll },
               },
             },
           }: IClass) => maxEnroll - enrolledCount;
@@ -197,7 +197,7 @@ export default function ClassBrowser({
           const getPercentOpenSeats = ({
             primarySection: {
               enrollment: {
-                latestEnrollment: { enrolledCount, maxEnroll },
+                latest: { enrolledCount, maxEnroll },
               },
             },
           }: IClass) =>

--- a/apps/frontend/src/components/ClassBrowser/index.tsx
+++ b/apps/frontend/src/components/ClassBrowser/index.tsx
@@ -183,17 +183,25 @@ export default function ClassBrowser({
 
         if (sortBy === SortBy.OpenSeats) {
           const getOpenSeats = ({
-            primarySection: { enrollCount, enrollMax },
-          }: IClass) => enrollMax - enrollCount;
+            primarySection: {
+              enrollment: {
+                latestEnrollment: { enrolledCount, maxEnroll },
+              },
+            },
+          }: IClass) => maxEnroll - enrolledCount;
 
           return getOpenSeats(b) - getOpenSeats(a);
         }
 
         if (sortBy === SortBy.PercentOpenSeats) {
           const getPercentOpenSeats = ({
-            primarySection: { enrollCount, enrollMax },
+            primarySection: {
+              enrollment: {
+                latestEnrollment: { enrolledCount, maxEnroll },
+              },
+            },
           }: IClass) =>
-            enrollMax === 0 ? 0 : (enrollMax - enrollCount) / enrollMax;
+            maxEnroll === 0 ? 0 : (maxEnroll - enrolledCount) / maxEnroll;
 
           return getPercentOpenSeats(b) - getPercentOpenSeats(a);
         }

--- a/apps/frontend/src/components/ClassBrowser/worker.ts
+++ b/apps/frontend/src/components/ClassBrowser/worker.ts
@@ -118,17 +118,25 @@ addEventListener(
 
       if (sortBy === SortBy.OpenSeats) {
         const getOpenSeats = ({
-          primarySection: { enrollCount, enrollMax },
-        }: IClass) => enrollMax - enrollCount;
+          primarySection: {
+            enrollment: {
+              latestEnrollment: { enrolledCount, maxEnroll },
+            },
+          },
+        }: IClass) => maxEnroll - enrolledCount;
 
         return getOpenSeats(b) - getOpenSeats(a);
       }
 
       if (sortBy === SortBy.PercentOpenSeats) {
         const getPercentOpenSeats = ({
-          primarySection: { enrollCount, enrollMax },
+          primarySection: {
+            enrollment: {
+              latestEnrollment: { enrolledCount, maxEnroll },
+            },
+          },
         }: IClass) =>
-          enrollMax === 0 ? 0 : (enrollMax - enrollCount) / enrollMax;
+          maxEnroll === 0 ? 0 : (maxEnroll - enrolledCount) / maxEnroll;
 
         return getPercentOpenSeats(b) - getPercentOpenSeats(a);
       }

--- a/apps/frontend/src/components/ClassBrowser/worker.ts
+++ b/apps/frontend/src/components/ClassBrowser/worker.ts
@@ -120,7 +120,7 @@ addEventListener(
         const getOpenSeats = ({
           primarySection: {
             enrollment: {
-              latestEnrollment: { enrolledCount, maxEnroll },
+              latest: { enrolledCount, maxEnroll },
             },
           },
         }: IClass) => maxEnroll - enrolledCount;
@@ -132,7 +132,7 @@ addEventListener(
         const getPercentOpenSeats = ({
           primarySection: {
             enrollment: {
-              latestEnrollment: { enrolledCount, maxEnroll },
+              latest: { enrolledCount, maxEnroll },
             },
           },
         }: IClass) =>

--- a/apps/frontend/src/lib/api/classes.ts
+++ b/apps/frontend/src/lib/api/classes.ts
@@ -1,11 +1,6 @@
 import { gql } from "@apollo/client";
 
-import {
-  GradeDistribution,
-  ICourse,
-  IEnrollmentSingular,
-  ISeatReservationType,
-} from ".";
+import { GradeDistribution, ICourse, IEnrollment } from ".";
 import { ITerm, Semester } from "./terms";
 
 export enum InstructionMethod {
@@ -129,11 +124,6 @@ export interface IExam {
   endTime: string;
 }
 
-export interface ILatestEnrollment {
-  latestEnrollment: IEnrollmentSingular;
-  seatReservationTypes: ISeatReservationType[];
-}
-
 export interface ISection {
   // Identifiers
   termId: string;
@@ -144,7 +134,7 @@ export interface ISection {
   term: ITerm;
   course: ICourse;
   class: IClass;
-  enrollment: ILatestEnrollment;
+  enrollment: IEnrollment;
 
   // Attributes
   year: number;
@@ -264,7 +254,7 @@ export const READ_CLASS = gql`
         startDate
         endDate
         enrollment {
-          latestEnrollment {
+          latest {
             status
             enrolledCount
             maxEnroll
@@ -304,7 +294,8 @@ export const READ_CLASS = gql`
         startDate
         endDate
         enrollment {
-          latestEnrollment {
+          latest {
+            status
             enrolledCount
             maxEnroll
             waitlistedCount
@@ -356,7 +347,7 @@ export const GET_CATALOG = gql`
         online
         instructionMode
         enrollment {
-          latestEnrollment {
+          latest {
             status
             enrolledCount
             maxEnroll

--- a/apps/frontend/src/lib/api/courses.ts
+++ b/apps/frontend/src/lib/api/courses.ts
@@ -1,15 +1,23 @@
 import { gql } from "@apollo/client";
 
-import {
-  AcademicCareer,
-  GradeDistribution,
-  IClass,
-  InstructionMethod,
-} from ".";
+import { GradeDistribution, IClass, InstructionMethod } from ".";
 import { Semester } from "./terms";
+
+export enum AcademicCareer {
+  Undergraduate = "UGRD",
+  Graduate = "GRAD",
+  Extension = "UCBX",
+}
+
+export const academicCareers: Record<AcademicCareer, string> = {
+  [AcademicCareer.Undergraduate]: "Undergraduate",
+  [AcademicCareer.Graduate]: "Graduate",
+  [AcademicCareer.Extension]: "Extension",
+};
 
 export interface ICourse {
   // Identifiers
+  courseId: string;
   subject: string;
   number: string;
 
@@ -21,13 +29,13 @@ export interface ICourse {
 
   // Attributes
   requirements: string | null;
-  primaryInstructionMethod: InstructionMethod;
   description: string;
   fromDate: string;
   gradingBasis: string;
   finalExam: string | null;
   academicCareer: AcademicCareer;
   title: string;
+  primaryInstructionMethod: InstructionMethod;
   toDate: string;
   typicallyOffered: Semester[] | null;
 }
@@ -39,6 +47,7 @@ export interface ReadCourseResponse {
 export const READ_COURSE = gql`
   query GetCourse($subject: String!, $number: CourseNumber!) {
     course(subject: $subject, number: $number) {
+      courseId
       subject
       number
       title

--- a/apps/frontend/src/lib/api/enrollment.ts
+++ b/apps/frontend/src/lib/api/enrollment.ts
@@ -1,0 +1,100 @@
+import { gql } from "@apollo/client";
+
+export interface ISeatReservationType {
+  number: number;
+  requirementGroup: string;
+  fromDate: string;
+}
+
+export enum EnrollmentStatus {
+  Closed = "C",
+  Open = "O",
+}
+
+export interface ISeatReservationCount {
+  number: number;
+  maxEnroll: number;
+  enrolledCount: number;
+}
+
+export interface IEnrollmentSingular {
+  time: string;
+  status: EnrollmentStatus;
+  enrolledCount: number;
+  reservedCount: number;
+  waitlistedCount: number;
+  minEnroll: number;
+  maxEnroll: number;
+  maxWaitlist: number;
+  openReserved: number;
+  instructorAddConsentRequired: boolean;
+  instructorDropConsentRequired: boolean;
+  seatReservationCounts: ISeatReservationCount[];
+}
+
+export interface IEnrollment {
+  termId: string;
+  year: number;
+  semester: string;
+  sessionId: string;
+  sectionId: string;
+  subject: string;
+  courseNumber: string;
+  sectionNumber: string;
+
+  seatReservationTypes: ISeatReservationType[];
+  history: IEnrollmentSingular[];
+}
+
+export interface ReadEnrollmentResponse {
+  enrollment: IEnrollment;
+}
+
+export const READ_ENROLLMENT = gql`
+  query GetEnrollment(
+    $year: Int!
+    $semester: Semester!
+    $sessionId: SessionIdentifier
+    $subject: String!
+    $courseNumber: CourseNumber!
+    $sectionNumber: SectionNumber!
+  ) {
+    enrollment(
+      year: $year
+      semester: $semester
+      sessionId: $sessionId
+      subject: $subject
+      courseNumber: $courseNumber
+      sectionNumber: $sectionNumber
+    ) {
+      year
+      semester
+      sessionId
+      sectionId
+      subject
+      courseNumber
+      sectionNumber
+      seatReservationTypes {
+        number
+        requirementGroup
+        fromDate
+      }
+      history {
+        time
+        status
+        enrolledCount
+        reservedCount
+        waitlistedCount
+        minEnroll
+        maxEnroll
+        maxWaitlist
+        openReserved
+        seatReservationCounts {
+          number
+          maxEnroll
+          enrolledCount
+        }
+      }
+    }
+  }
+`;

--- a/apps/frontend/src/lib/api/enrollment.ts
+++ b/apps/frontend/src/lib/api/enrollment.ts
@@ -44,6 +44,7 @@ export interface IEnrollment {
 
   seatReservationTypes: ISeatReservationType[];
   history: IEnrollmentSingular[];
+  latest: IEnrollmentSingular;
 }
 
 export interface ReadEnrollmentResponse {

--- a/apps/frontend/src/lib/api/grade-distributions.ts
+++ b/apps/frontend/src/lib/api/grade-distributions.ts
@@ -17,22 +17,24 @@ export interface ReadGradeDistributionResponse {
 
 export const READ_GRADE_DISTRIBUTION = gql`
   query GetGradeDistribution(
+    $year: Int
+    $semester: Semester
+    $sessionId: SessionIdentifier
     $subject: String!
     $courseNumber: CourseNumber!
     $classNumber: ClassNumber
-    $year: Int
-    $semester: Semester
-    $givenName: String
     $familyName: String
+    $givenName: String
   ) {
     grade(
+      year: $year
+      semester: $semester
+      sessionId: $sessionId
       subject: $subject
       courseNumber: $courseNumber
       classNumber: $classNumber
-      year: $year
-      semester: $semester
-      givenName: $givenName
       familyName: $familyName
+      givenName: $givenName
     ) {
       average
       distribution {

--- a/apps/frontend/src/lib/api/index.ts
+++ b/apps/frontend/src/lib/api/index.ts
@@ -4,3 +4,4 @@ export * from "./courses";
 export * from "./terms";
 export * from "./schedules";
 export * from "./grade-distributions";
+export * from "./enrollment";

--- a/apps/frontend/src/lib/api/schedules.ts
+++ b/apps/frontend/src/lib/api/schedules.ts
@@ -49,6 +49,7 @@ export interface ISchedule {
   term: ITerm;
   year: number;
   semester: Semester;
+  sessionId: string;
 }
 
 export interface ReadScheduleResponse {
@@ -65,32 +66,37 @@ export const READ_SCHEDULE = gql`
       year
       semester
       term {
-        startDate
+        beginDate
         endDate
       }
       classes {
         class {
           subject
-          unitsMax
-          unitsMin
           courseNumber
           number
+          unitsMax
+          unitsMin
           course {
             title
           }
           primarySection {
+            sectionId
+            subject
             courseNumber
             classNumber
-            subject
             number
             startDate
             endDate
-            ccn
             component
-            enrollCount
-            enrollMax
-            waitlistCount
-            waitlistMax
+            enrollment {
+              latestEnrollment {
+                status
+                enrolledCount
+                maxEnroll
+                waitlistedCount
+                maxWaitlist
+              }
+            }
             meetings {
               days
               location
@@ -110,18 +116,23 @@ export const READ_SCHEDULE = gql`
             }
           }
           sections {
-            number
+            sectionId
+            subject
             courseNumber
             classNumber
-            subject
-            ccn
-            component
-            enrollCount
+            number
             startDate
             endDate
-            enrollMax
-            waitlistCount
-            waitlistMax
+            component
+            enrollment {
+              latestEnrollment {
+                status
+                enrolledCount
+                maxEnroll
+                waitlistedCount
+                maxWaitlist
+              }
+            }
             meetings {
               days
               location
@@ -167,26 +178,31 @@ export const UPDATE_SCHEDULE = gql`
       classes {
         class {
           subject
-          unitsMax
-          unitsMin
           courseNumber
           number
+          unitsMax
+          unitsMin
           course {
             title
           }
           primarySection {
+            sectionId
+            subject
             courseNumber
             classNumber
-            subject
             number
             startDate
             endDate
-            ccn
             component
-            enrollCount
-            enrollMax
-            waitlistCount
-            waitlistMax
+            enrollment {
+              latestEnrollment {
+                status
+                enrolledCount
+                maxEnroll
+                waitlistedCount
+                maxWaitlist
+              }
+            }
             meetings {
               days
               location
@@ -206,18 +222,23 @@ export const UPDATE_SCHEDULE = gql`
             }
           }
           sections {
-            number
+            sectionId
+            subject
             courseNumber
             classNumber
-            subject
-            ccn
-            component
-            enrollCount
+            number
             startDate
             endDate
-            enrollMax
-            waitlistCount
-            waitlistMax
+            component
+            enrollment {
+              latestEnrollment {
+                status
+                enrolledCount
+                maxEnroll
+                waitlistedCount
+                maxWaitlist
+              }
+            }
             meetings {
               days
               location
@@ -266,6 +287,7 @@ export const CREATE_SCHEDULE = gql`
       year
       createdBy
       semester
+      sessionId
       classes {
         class {
           subject
@@ -289,6 +311,7 @@ export const READ_SCHEDULES = gql`
       name
       year
       semester
+      sessionId
       classes {
         class {
           subject

--- a/apps/frontend/src/lib/api/schedules.ts
+++ b/apps/frontend/src/lib/api/schedules.ts
@@ -89,7 +89,7 @@ export const READ_SCHEDULE = gql`
             endDate
             component
             enrollment {
-              latestEnrollment {
+              latest {
                 status
                 enrolledCount
                 maxEnroll
@@ -125,7 +125,7 @@ export const READ_SCHEDULE = gql`
             endDate
             component
             enrollment {
-              latestEnrollment {
+              latest {
                 status
                 enrolledCount
                 maxEnroll
@@ -195,7 +195,7 @@ export const UPDATE_SCHEDULE = gql`
             endDate
             component
             enrollment {
-              latestEnrollment {
+              latest {
                 status
                 enrolledCount
                 maxEnroll
@@ -231,7 +231,7 @@ export const UPDATE_SCHEDULE = gql`
             endDate
             component
             enrollment {
-              latestEnrollment {
+              latest {
                 status
                 enrolledCount
                 maxEnroll

--- a/apps/frontend/src/lib/api/terms.ts
+++ b/apps/frontend/src/lib/api/terms.ts
@@ -42,7 +42,7 @@ export const READ_TERMS = gql`
       sessions {
         name
         startDate
-        startDate
+        endDate
         temporalPosition
       }
       startDate

--- a/apps/frontend/src/lib/api/terms.ts
+++ b/apps/frontend/src/lib/api/terms.ts
@@ -24,7 +24,7 @@ export interface ITerm {
   year: number;
   semester: Semester;
   temporalPosition: TemporalPosition;
-  sessions: ISession[];
+  sessions: ISession[] | null;
   startDate?: string;
   endDate?: string;
 }
@@ -42,7 +42,7 @@ export const READ_TERMS = gql`
       sessions {
         name
         startDate
-        endDate
+        startDate
         temporalPosition
       }
       startDate

--- a/apps/frontend/src/lib/api/users.ts
+++ b/apps/frontend/src/lib/api/users.ts
@@ -32,6 +32,7 @@ export const READ_USER = gql`
         courseNumber
         year
         semester
+        sessionId
       }
     }
   }
@@ -48,6 +49,7 @@ export interface IBookmarkedClassInput {
   courseNumber: string;
   year: number;
   semester: Semester;
+  sessionId: string | null;
 }
 
 export interface IUserInput {
@@ -76,6 +78,7 @@ export const UPDATE_USER = gql`
         courseNumber
         year
         semester
+        sessionId
       }
     }
   }

--- a/packages/common/src/models/classNew.ts
+++ b/packages/common/src/models/classNew.ts
@@ -75,7 +75,7 @@ const classSchema = new Schema<IClassItem>({
 classSchema.index(
   {
     year: 1,
-    semetser: 1,
+    semester: 1,
     sessionId: 1,
     subject: 1,
     courseNumber: 1,

--- a/packages/common/src/models/classNew.ts
+++ b/packages/common/src/models/classNew.ts
@@ -72,18 +72,18 @@ const classSchema = new Schema<IClassItem>({
   requirementDesignation: { type: String }, // NOTE: Exclude if always the same as course requirementsFulfilled, requirementDesignation.code
   requisites: { type: String }, // requisites.description
 });
-// classes are unique by termId, courseId, number, subject, and courseNumber
 classSchema.index(
   {
-    termId: 1,
+    year: 1,
+    semetser: 1,
     sessionId: 1,
-    courseId: 1,
-    number: 1,
     subject: 1,
     courseNumber: 1,
+    number: 1,
   },
   { unique: true }
 );
+classSchema.index({ courseId: 1 });
 
 export const NewClassModel: Model<IClassItem> = model<IClassItem>(
   "NewClass",

--- a/packages/common/src/models/courseNew.ts
+++ b/packages/common/src/models/courseNew.ts
@@ -146,14 +146,14 @@ const courseSchema = new Schema<ICourseItem>({
     recommendedText: { type: String },
     recommendedCourses: { type: [String] },
     requiredText: { type: String },
-    requiredCourses: { type: [String] },
+    requiredCourses: { type: [String] }, // stored as courseIds
   },
   gradeReplacement: {
     text: { type: String },
     group: { type: String },
     courses: { type: [String] },
   },
-  crossListing: { type: [String] },
+  crossListing: { type: [String] }, // stored as `${subject} ${number}`
   formatsOffered: {
     description: { type: String },
     typicallyOffered: {
@@ -207,6 +207,13 @@ const courseSchema = new Schema<ICourseItem>({
   updatedDate: { type: String },
 });
 courseSchema.index({ courseId: 1 }, { unique: true });
+courseSchema.index(
+  {
+    subject: 1,
+    number: 1,
+  },
+  { unique: true }
+);
 
 export const NewCourseModel: Model<ICourseItem> = model<ICourseItem>(
   "NewCourse",

--- a/packages/common/src/models/grade-distribution.ts
+++ b/packages/common/src/models/grade-distribution.ts
@@ -10,7 +10,7 @@ export interface IGradeDistributionItem {
   sessionId: string;
 
   // TODO: CCN?
-  classNumber: string;
+  sectionId: string;
   sectionNumber: string;
 
   // Grade distribution
@@ -55,7 +55,7 @@ const gradeDistributionSchema = new Schema<IGradeDistributionItem>(
     termId: { type: String, required: true },
     sessionId: { type: String, required: true },
 
-    classNumber: { type: String, required: true },
+    sectionId: { type: String, required: true },
     sectionNumber: { type: String, required: true },
 
     count: { type: Number, required: true },
@@ -92,6 +92,10 @@ gradeDistributionSchema.index(
   { termId: 1, classNumber: 1, sectionNumber: 1 },
   { unique: true }
 );
+gradeDistributionSchema.index({
+  subject: 1,
+  courseNumber: 1,
+});
 
 export const GradeDistributionModel = mongoose.model(
   "GradeDistributions",

--- a/packages/common/src/models/schedule.ts
+++ b/packages/common/src/models/schedule.ts
@@ -49,7 +49,7 @@ export const selectedClassSchema = new Schema({
     trim: true,
     required: true,
   },
-  sections: {
+  sectionIds: {
     type: [Number],
     required: false,
   },
@@ -82,6 +82,10 @@ export const scheduleSchema = new Schema(
     },
     semester: {
       ...semester,
+      required: true,
+    },
+    sessionId: {
+      type: String,
       required: true,
     },
     events: {

--- a/packages/common/src/models/sectionNew.ts
+++ b/packages/common/src/models/sectionNew.ts
@@ -24,20 +24,6 @@ export interface ISectionItem {
   primary?: boolean;
   type?: string;
   combinedSections?: number[];
-  enrollment?: {
-    status?: string;
-    enrolledCount?: number;
-    minEnroll?: number;
-    maxEnroll?: number;
-    waitlistedCount?: number;
-    maxWaitlist?: number;
-    reservations?: {
-      number?: number;
-      requirementGroup?: string;
-      maxEnroll?: number;
-      enrolledCount?: number;
-    }[];
-  };
   exams?: {
     date?: string;
     startTime?: string;
@@ -66,14 +52,20 @@ export interface ISectionItem {
 export interface ISectionItemDocument extends ISectionItem, Document {}
 
 const sectionSchema = new Schema<ISectionItem>({
+  // identifiers
+  termId: { type: String, required: true },
+  sessionId: { type: String, required: true },
+  sectionId: { type: String, required: true },
+
+  // relationships
   courseId: { type: String, required: true },
   classNumber: { type: String, required: true },
-  sessionId: { type: String, required: true },
-  termId: { type: String, required: true },
-  sectionId: { type: String, required: true },
-  number: { type: String, required: true },
   subject: { type: String, required: true },
   courseNumber: { type: String, required: true },
+  number: { type: String, required: true },
+  primary: { type: Boolean },
+
+  // attributes
   year: { type: Number, required: true },
   semester: { type: String, required: true },
   component: { type: String },
@@ -86,25 +78,8 @@ const sectionSchema = new Schema<ISectionItem>({
   endDate: { type: String },
   addConsentRequired: { type: String },
   dropConsentRequired: { type: String },
-  primary: { type: Boolean },
   type: { type: String },
   combinedSections: { type: [Number] },
-  enrollment: {
-    status: { type: String },
-    enrolledCount: { type: Number },
-    minEnroll: { type: Number },
-    maxEnroll: { type: Number },
-    waitlistedCount: { type: Number },
-    maxWaitlist: { type: Number },
-    reservations: [
-      {
-        number: { type: Number },
-        requirementGroup: { type: String },
-        maxEnroll: { type: Number },
-        enrolledCount: { type: Number },
-      },
-    ],
-  },
   exams: [
     {
       date: { type: String },
@@ -137,6 +112,17 @@ const sectionSchema = new Schema<ISectionItem>({
 });
 sectionSchema.index(
   { termId: 1, sessionId: 1, sectionId: 1 },
+  { unique: true }
+);
+sectionSchema.index(
+  {
+    year: 1,
+    semester: 1,
+    sessionId: 1,
+    subject: 1,
+    courseNumber: 1,
+    number: 1,
+  },
   { unique: true }
 );
 

--- a/packages/common/src/models/termNew.ts
+++ b/packages/common/src/models/termNew.ts
@@ -121,6 +121,7 @@ const termSchema = new Schema<ITermItem>({
   },
 });
 termSchema.index({ id: 1, academicCareerCode: 1 }, { unique: true });
+termSchema.index({ name: 1 });
 
 export const NewTermModel: Model<ITermItem> = model<ITermItem>(
   "NewTerm",


### PR DESCRIPTION
## Backend

Refactors all resolvers/controllers to use new database models. Query designs are kept as identical as possible. 

Small GraphQL typdef changes including:
- `sessionId` with all queries requiring year/semester
  - field isn't required, default value is '1' (explicit at each query). 
  - if semester is 'Summer', will silently return [] (unless valid `sessionId` is provided)
- section type now includes latest `EnrollmentSingular`, including status (replacing `open`)
- scheduler auto-populates sectionIds as sections objects

Renamed `classNumber` field to `sectionId` field in grade-distribution schema. 


## Frontend 
Refactors frontend variable naming:
- enrollCount -> enrolledCount
- enrollMax -> maxEnroll
- waitlistCount -> waitlistedCount
- waitlistMax -> maxWaitlist

This reflects the SIS API naming. 

Also, added an API file for the enrollment queries. 


## TODO:
- [ ] delete all old models
- [ ] rename new models (remove "New" prefixes)
- [ ] deploy to prod and create indices (not auto created)