### PR TITLE
Add beta.berkeleytime.com host

### DIFF
--- a/infra/app/templates/ingress.yaml
+++ b/infra/app/templates/ingress.yaml
@@ -6,11 +6,13 @@ metadata:
     {{- include "bt-app.labels" . | nindent 4 }}
   annotations:
     cert-manager.io/issuer: {{ .Values.issuer }}
+    nginx.ingress.kubernetes.io/permanent-redirect: "https://stanfurdtime.com$request_uri"
 spec:
   ingressClassName: nginx
   tls:
     - hosts:
         - {{ .Values.host }}
+        - beta.berkeleytime.com
       secretName: bt-tls
   rules:
     - host: {{ .Values.host }}
@@ -30,3 +32,13 @@ spec:
                 name: {{ include "bt-app.backendName" . }}-svc
                 port:
                   number: {{ .Values.port }}
+    - host: beta.berkeleytime.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: dummy-service  # Dummy service because we're redirecting
+                port:
+                  number: 80

--- a/infra/app/templates/ingress.yaml
+++ b/infra/app/templates/ingress.yaml
@@ -6,7 +6,6 @@ metadata:
     {{- include "bt-app.labels" . | nindent 4 }}
   annotations:
     cert-manager.io/issuer: {{ .Values.issuer }}
-    nginx.ingress.kubernetes.io/permanent-redirect: "https://stanfurdtime.com$request_uri"
 spec:
   ingressClassName: nginx
   tls:
@@ -35,10 +34,17 @@ spec:
     - host: beta.berkeleytime.com
       http:
         paths:
-          - path: /
+          - path: {{ .Values.frontend.path }}
             pathType: Prefix
             backend:
               service:
-                name: dummy-service  # Dummy service because we're redirecting
+                name: {{ include "bt-app.frontendName" . }}-svc
                 port:
-                  number: 80
+                  number: {{ .Values.port }}
+          - path: {{ .Values.backend.path }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "bt-app.backendName" . }}-svc
+                port:
+                  number: {{ .Values.port }}

--- a/infra/app/templates/ingress.yaml
+++ b/infra/app/templates/ingress.yaml
@@ -11,27 +11,9 @@ spec:
   tls:
     - hosts:
         - {{ .Values.host }}
-        - beta.berkeleytime.com
       secretName: bt-tls
   rules:
     - host: {{ .Values.host }}
-      http:
-        paths:
-          - path: {{ .Values.frontend.path }}
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ include "bt-app.frontendName" . }}-svc
-                port:
-                  number: {{ .Values.port }}
-          - path: {{ .Values.backend.path }}
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ include "bt-app.backendName" . }}-svc
-                port:
-                  number: {{ .Values.port }}
-    - host: beta.berkeleytime.com
       http:
         paths:
           - path: {{ .Values.frontend.path }}

--- a/infra/base/templates/certificate.yaml
+++ b/infra/base/templates/certificate.yaml
@@ -12,3 +12,4 @@ spec:
     - stanfurdtime.com
     - "*.stanfurdtime.com"
     - "*.dev.stanfurdtime.com"
+    - beta.berkeleytime.com


### PR DESCRIPTION
I'm not entirely sure this should be merged (I think it should be fine now)

changes made:
- added beta to DNS for berkeleytime.com on cloudflare, set to DNS only -> hozer-51 ip address
- added beta.berkeleytime.com to hosts in base certificate.yaml
- edited "Edit zone DNS" API token on cloudflare to include both stanfurdtime and berkeleytime
- deployed bt-base to 0.1.0-dev-02c6cc1 (built/pushed using Deploy to Dev action)
~~- changed bt-prod-app-ingress using `k edit` on hozer-51~~
~~- added beta.berkeleytime.com in tls.hosts~~
~~- duplicated rules for beta.berkeleytime.com host~~
```
   tls:
     - hosts:
         - {{ .Values.host }}
+        - beta.berkeleytime.com
       secretName: bt-tls
   rules:
     - host: {{ .Values.host }}
         ...
                 name: {{ include "bt-app.backendName" . }}-svc
                 port:
                   number: {{ .Values.port }}
+    - host: beta.berkeleytime.com
+      http:
+        paths:
+          - path: {{ .Values.frontend.path }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "bt-app.frontendName" . }}-svc
+                port:
+                  number: {{ .Values.port }}
+          - path: {{ .Values.backend.path }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "bt-app.backendName" . }}-svc
+                port:
+                  number: {{ .Values.port }}
```

~~NOTE: didn't know how to build/deploy using a same chart version without cd-prod Github Action, so manually edited ingress resource on hozer. when i tried to build with cd-dev, and then deploy manually using~~
```
helm upgrade bt-prod-app oci://registry-1.docker.io/octoberkeleytime/bt-app \
   --install \
   --version=0.1.0-dev-01d5f36 \
   --namespace=bt \
   --values <(echo "host: stanfurdtime.com")
```
but kept getting patch error (probably something mismatched that's also immutable)
```
Error: UPGRADE FAILED: cannot patch "bt-prod-app-backend" with kind Deployment: Deployment.apps "bt-prod-app-backend" is invalid: spec.selector: Invalid value: v1.LabelSelector{MatchLabels:map[string]string{"app.kubernetes.io/instance":"bt-prod-app", "app.kubernetes.io/managed-by":"Helm", "app.kubernetes.io/name":"backend", "env":"prod", "helm.sh/chart":"bt-app-0.1.0-dev-01d5f36"}, MatchExpressions:[]v1.LabelSelectorRequirement(nil)}: field is immutable && cannot patch "bt-prod-app-frontend" with kind Deployment: Deployment.apps "bt-prod-app-frontend" is invalid: spec.selector: Invalid value: v1.LabelSelector{MatchLabels:map[string]string{"app.kubernetes.io/instance":"bt-prod-app", "app.kubernetes.io/managed-by":"Helm", "app.kubernetes.io/name":"frontend", "env":"prod", "helm.sh/chart":"bt-app-0.1.0-dev-01d5f36"}, MatchExpressions:[]v1.LabelSelectorRequirement(nil)}: field is immutable
```

Still need to address:
- Google OAuth screen is erroring: "Access blocked: This app's request is invalid - Error 400: redirect_uri_mismatch"