### PR TITLE
(docs) update database seed instructions

### DIFF
--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -7,6 +7,9 @@ Welcome to the Berkeleytime Docs! This is the primary documentation source for d
 
 ## Getting Started
 
+> [!NOTE]
+> The following are instructions to set up the documentation locally. To set up the Berkeleytime app locally, go to the [Local Development](./getting-started/local-development.md) section.
+
 ### Developing and Building Locally
 
 There are two options: with and without containerization (ie. Docker).

--- a/docs/src/getting-started/local-development.md
+++ b/docs/src/getting-started/local-development.md
@@ -53,9 +53,15 @@ A seeded database is required for some pages on the frontend.
 docker compose up -d
 
 # Download the data
-curl -O https://storage.googleapis.com/berkeleytime/public/stage_backup.gz
+curl -f -o "prod-backup.gz" "https://backups.stanfurdtime.com/persistent/prod_backup-$(date +%Y%m01).gz"
 
 # Copy the data and restore
-docker cp ./stage_backup.gz berkeleytime-mongodb-1:/tmp/stage_backup.gz
-docker exec berkeleytime-mongodb-1 mongorestore --drop --gzip --archive=/tmp/stage_backup.gz
+docker cp ./prod-backup.gz berkeleytime-mongodb-1:/tmp/prod-backup.gz
+docker exec berkeleytime-mongodb-1 mongorestore --drop --gzip --archive=/tmp/prod-backup.gz
 ```
+
+> [!TIP]
+> For the latest available snapshot of the production database, use:
+> ```sh
+> curl -f -o "prod-backup.gz" "https://backups.stanfurdtime.com/daily/prod_backup-$(date +%Y%m%d).gz"
+> ```


### PR DESCRIPTION
Updates database seeding instructions to seed from `hozer-51` database instead of `hozer-55` database. 

We are using Cloudflare's R2 buckets instead of GCP's buckets. 

We should probably use the staging database instead to protect the privacy of our users (schedule/user data). Also since grades data shouldn't be publicly available. 

Tested locally. (20250801 doesn't exist since I only just changed our backup frequency to twice a year to once a month). 