### PR TITLE
fix terms datapuller

### DIFF
--- a/apps/datapuller/src/pullers/terms.ts
+++ b/apps/datapuller/src/pullers/terms.ts
@@ -23,7 +23,7 @@ const updateTerms = async (
   log.trace("Deleting terms to be replaced...");
 
   const { deletedCount } = await TermModel.deleteMany({
-    id: { $nin: termIds },
+    id: { $in: termIds },
   });
 
   log.info(`Deleted ${deletedCount.toLocaleString()} terms.`);


### PR DESCRIPTION
Fixes bug (probably a typo) where terms datapuller deletes all terms not in incoming terms. Should be delete all terms in incoming terms (to update those). 