### PR TITLE
Fix: Catalog bookmark "view all"

### DIFF
--- a/apps/frontend/src/app/Catalog/Dashboard/index.tsx
+++ b/apps/frontend/src/app/Catalog/Dashboard/index.tsx
@@ -125,7 +125,7 @@ export default function Dashboard({
           <Carousel.Root
             title="Bookmarked"
             Icon={<BookmarkSolid />}
-            to="/account"
+            to="/profile"
           >
             {/* TODO: Better placeholder states */}
             {!bookmarkedClasses ? (


### PR DESCRIPTION
## Description
Fix the problem of navigate to an empty /account route.
<img width="800" height="208" alt="image" src="https://github.com/user-attachments/assets/ecb6e167-d7c1-4a7d-a469-827d460bd17f" />

## Original behavior
After clicking "view all", it will navigate to the homepage.

## Fixed behavior
It will navigate to the account page, but I'm not sure whether this is the correct choice.

<img width="1484" height="674" alt="image" src="https://github.com/user-attachments/assets/7333eb49-6590-43e8-a67f-b3c5eedf0e3a" />
