### PR TITLE
(cicd) auth functionality in dev deploy

### DIFF
--- a/.github/workflows/cd-dev.yaml
+++ b/.github/workflows/cd-dev.yaml
@@ -19,7 +19,7 @@ on:
         default: false
 
 env:
-  HOSTS: "beta.berkeleytime.com auth1.stanfurdtime.com"
+  HOSTS: "auth0.dev.stanfurdtime.com auth1.dev.stanfurdtime.com auth2.dev.stanfurdtime.com auth3.dev.stanfurdtime.com auth4.dev.stanfurdtime.com auth5.dev.stanfurdtime.com auth6.dev.stanfurdtime.com auth7.dev.stanfurdtime.com auth8.dev.stanfurdtime.com auth9.dev.stanfurdtime.com"
 
 jobs:
   compute-sha:
@@ -62,7 +62,7 @@ jobs:
           if [ -z $auth_host ]; then
             echo "host=$sha_short.dev.stanfurdtime.com" >> $GITHUB_OUTPUT
           else
-            echo "host=$auth_host.dev.stanfurdtime.com" >> $GITHUB_OUTPUT
+            echo "host=$auth_host" >> $GITHUB_OUTPUT
           fi
 
   build-push:


### PR DESCRIPTION
Previously, auth was not supported in dev deploy due to the commit hash-based subdomains that we host dev deployments to. These dynamically generated subdomains is not easily matched in the Google OAuth configs. 

Now, upon passing in a boolean flag during the build step, the subdomains can be fixed (`auth0.dev.stanfurdtime.com`, ..., `auth9.dev.stanfurdtime.com`). 

> [!WARNING] 
> If you deploy a dev branch without the auth flag, then try to deploy _the same commit_ with the auth flag, it will cause an error. To resolve this, you have to ssh into the machine and `helm uninstall` the original release. (This behavior existed even before this PR unfortunately: https://www.notion.so/berkeleytimeteam/fix-cicd-dev-bug-1d8a86d7e7df8073a920c1cf1805d04b?source=copy_link)