### PR TITLE
use staging mongo and redis in dev deploys

### DIFF
--- a/.github/workflows/cd-dev.yaml
+++ b/.github/workflows/cd-dev.yaml
@@ -96,8 +96,8 @@ jobs:
           image:
             tag: '${{ needs.compute-sha.outputs.sha_short }}'
         host: ${{ needs.compute-sha.outputs.host }}
-        mongoUri: mongodb://bt-dev-mongo-mongodb-0.bt-dev-mongo-mongodb-headless.bt.svc.cluster.local:27017/bt
-        redisUri: redis://bt-dev-redis-master.bt.svc.cluster.local:6379
+        mongoUri: mongodb://bt-stage-mongo-mongodb-0.bt-stage-mongo-mongodb-headless.bt.svc.cluster.local:27017/bt
+        redisUri: redis://bt-stage-redis-master.bt.svc.cluster.local:6379
       host: ${{ needs.compute-sha.outputs.host }}
     secrets: inherit
 


### PR DESCRIPTION
Changes `cd-dev.yaml` helm chart override values to point to staging mongo/redis. 