### PR TITLE
fixes enrollment graph bug

### DIFF
--- a/apps/frontend/src/app/Enrollment/index.tsx
+++ b/apps/frontend/src/app/Enrollment/index.tsx
@@ -226,7 +226,7 @@ export default function Enrollment() {
         }
         return datapoint;
       })
-      .sort((a, b) => a.timeDelta - b.timeDelta);
+      .sort((a, b) => a.timeDelta - b.timeDelta); // set doesn't guarantee order, so we sort by timeDelta
   }, [outputs]);
 
   function updateGraphHover(data: {


### PR DESCRIPTION
Fixes enrollment graph bug by sorting time series (even though it's sorted in the backend, the way the time series data structure is constructed on the frontend doesn't guarantee it's still sorted). 

Before: 
<img width="1917" height="778" alt="image" src="https://github.com/user-attachments/assets/0aea1e66-2cc2-4a11-861f-896f620d7e27" />

After:
<img width="1342" height="543" alt="Screenshot 2025-10-28 at 3 15 24 PM" src="https://github.com/user-attachments/assets/8e0876f4-e32b-4684-af2a-9d662a24469c" />
