### PR TITLE
waitlist predictor on enrollment page

### DIFF
--- a/apps/backend/src/modules/index.ts
+++ b/apps/backend/src/modules/index.ts
@@ -20,6 +20,7 @@ import Staff from "./staff";
 import TargetedMessage from "./targeted-message";
 import Term from "./term";
 import User from "./user";
+import Waitlist from "./waitlist";
 
 const modules = [
   Analytics,
@@ -42,6 +43,7 @@ const modules = [
   RouteRedirect,
   Pod,
   TargetedMessage,
+  Waitlist,
 ];
 
 export const resolvers = merge(modules.map((module) => module.resolver));

--- a/apps/backend/src/modules/waitlist/controller.ts
+++ b/apps/backend/src/modules/waitlist/controller.ts
@@ -1,0 +1,163 @@
+import { NewEnrollmentHistoryModel } from "@repo/common/models";
+
+import { Semester } from "../../generated-types/graphql";
+import { buildSubjectQuery } from "../../utils/subject";
+
+const LAMBDA_DEFAULT = 0.5; // waitlist decreases per day when no estimate available
+const SEMESTERS_FOR_LAMBDA_ESTIMATE = 3;
+/** Once waitlist has been at 0 for this many days, we stop counting (waitlist phase ended). */
+const WAITLIST_ZERO_CUTOFF_DAYS = 10;
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+// Semester order for "most recent first": Fall > Spring > Summer within a year.
+const SEMESTER_ORDER: Record<string, number> = {
+  Fall: 3,
+  Spring: 2,
+  Summer: 1,
+};
+
+// P(X < k) for X ~ Poisson(lambdaT). Sum of e^{-lambdaT} * (lambdaT)^i / i! for i = 0 .. k-1.
+function poissonCdf(k: number, lambdaT: number): number {
+  if (lambdaT < 0 || k < 1) return 0;
+  let sum = 0;
+  let term = Math.exp(-lambdaT);
+  for (let i = 0; i < k; i++) {
+    sum += term;
+    term *= lambdaT / (i + 1);
+  }
+  return sum;
+}
+
+// P(get in) = 1 - P(X < k) where X is number of drops in time T, X ~ Poisson(lambda * T)
+
+export function getWaitlistGetInProbability(
+  k: number,
+  timeRemainingDays: number,
+  lambda?: number
+): { probability: number; lambdaUsed: number } {
+  const lambdaUsed = lambda ?? LAMBDA_DEFAULT;
+  const lambdaT = lambdaUsed * timeRemainingDays;
+  const pNoGetIn = poissonCdf(k, lambdaT);
+  const probability = Math.max(0, Math.min(1, 1 - pNoGetIn));
+  return { probability, lambdaUsed };
+}
+
+export interface WaitlistSectionInput {
+  year: number;
+  semester: Semester;
+  sessionId: string | null;
+  subject: string;
+  courseNumber: string;
+  sectionNumber: string;
+}
+
+type HistoryEntry = {
+  startTime: Date;
+  endTime: Date;
+  waitlistedCount?: number;
+};
+
+/**
+ * Find the index to truncate at: once waitlist has been 0 for at least
+ * WAITLIST_ZERO_CUTOFF_DAYS, we stop (waitlist phase ended). Returns the last
+ * index to include (inclusive), or sorted.length - 1 if no such cutoff.
+ */
+function truncateAtWaitlistZeroCutoff(sorted: HistoryEntry[]): number {
+  let runStart: number | null = null;
+
+  for (let i = 0; i < sorted.length; i++) {
+    const w = sorted[i].waitlistedCount ?? 0;
+    if (w === 0) {
+      if (runStart === null) runStart = i;
+      const runStartTime = new Date(sorted[runStart].startTime).getTime();
+      const runEndTime = new Date(sorted[i].endTime).getTime();
+      const runDays = (runEndTime - runStartTime) / MS_PER_DAY;
+      if (runDays >= WAITLIST_ZERO_CUTOFF_DAYS) {
+        return runStart - 1;
+      }
+    } else {
+      runStart = null;
+    }
+  }
+  return sorted.length - 1;
+}
+
+/**
+ * Count waitlist decreases and time span from a semester's history.
+ * Only decreases in waitlistedCount count; increases count as 0 (not negative).
+ * Stops counting once waitlist has been at 0 for WAITLIST_ZERO_CUTOFF_DAYS
+ * (waitlist phase ended).
+ */
+function waitlistDecreasesAndDaysFromHistory(history: HistoryEntry[]): {
+  waitlistDecreases: number;
+  days: number;
+} {
+  if (history.length === 0) return { waitlistDecreases: 0, days: 0 };
+
+  const sorted = [...history].sort(
+    (a, b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime()
+  );
+
+  const lastIdx = truncateAtWaitlistZeroCutoff(sorted);
+  if (lastIdx < 0) return { waitlistDecreases: 0, days: 0 };
+
+  let waitlistDecreases = 0;
+  for (let i = 1; i <= lastIdx; i++) {
+    const prev = sorted[i - 1].waitlistedCount ?? 0;
+    const curr = sorted[i].waitlistedCount ?? 0;
+    if (prev > curr) waitlistDecreases += prev - curr;
+  }
+
+  const firstStart = new Date(sorted[0].startTime).getTime();
+  const lastEnd = new Date(sorted[lastIdx].endTime).getTime();
+  const days = Math.max(0, (lastEnd - firstStart) / MS_PER_DAY);
+
+  return { waitlistDecreases, days };
+}
+
+/**
+ * Estimate lambda (waitlist decreases per day) from a section's enrollment history
+ * across the last 3 semesters. Uses consecutive history entries: decreases in
+ * waitlistedCount count as waitlist decreases; increases count as 0.
+ * Returns null if no history or not enough data.
+ */
+export async function estimateLambdaFromEnrollmentHistory(
+  section: WaitlistSectionInput
+): Promise<number | null> {
+  const subjectQuery = buildSubjectQuery(section.subject);
+
+  const enrollments = await NewEnrollmentHistoryModel.find({
+    sessionId: section.sessionId ?? "1",
+    subject: subjectQuery,
+    courseNumber: section.courseNumber,
+    sectionNumber: section.sectionNumber,
+  })
+    .select({ year: 1, semester: 1, history: 1 })
+    .lean();
+
+  if (enrollments.length === 0) return null;
+
+  const sortedEnrollments = [...enrollments].sort((a, b) => {
+    if (a.year !== b.year) return b.year - a.year;
+    return (
+      (SEMESTER_ORDER[b.semester] ?? 0) - (SEMESTER_ORDER[a.semester] ?? 0)
+    );
+  });
+
+  const lastN = sortedEnrollments.slice(0, SEMESTERS_FOR_LAMBDA_ESTIMATE);
+
+  let totalWaitlistDecreases = 0;
+  let totalDays = 0;
+
+  for (const doc of lastN) {
+    const history = (doc.history ?? []) as HistoryEntry[];
+    if (history.length === 0) continue;
+    const { waitlistDecreases, days } =
+      waitlistDecreasesAndDaysFromHistory(history);
+    totalWaitlistDecreases += waitlistDecreases;
+    totalDays += days;
+  }
+
+  if (totalDays <= 0) return null;
+  return totalWaitlistDecreases / totalDays;
+}

--- a/apps/backend/src/modules/waitlist/controller.ts
+++ b/apps/backend/src/modules/waitlist/controller.ts
@@ -61,6 +61,8 @@ type HistoryEntry = {
  * Find the index to truncate at: once waitlist has been 0 for at least
  * WAITLIST_ZERO_CUTOFF_DAYS, we stop (waitlist phase ended). Returns the last
  * index to include (inclusive), or sorted.length - 1 if no such cutoff.
+ * Includes the first zero bucket so we count the final decrease (e.g. 5 -> 0)
+ * and elapsed time up to that transition.
  */
 function truncateAtWaitlistZeroCutoff(sorted: HistoryEntry[]): number {
   let runStart: number | null = null;
@@ -73,7 +75,7 @@ function truncateAtWaitlistZeroCutoff(sorted: HistoryEntry[]): number {
       const runEndTime = new Date(sorted[i].endTime).getTime();
       const runDays = (runEndTime - runStartTime) / MS_PER_DAY;
       if (runDays >= WAITLIST_ZERO_CUTOFF_DAYS) {
-        return runStart - 1;
+        return runStart;
       }
     } else {
       runStart = null;

--- a/apps/backend/src/modules/waitlist/controller.ts
+++ b/apps/backend/src/modules/waitlist/controller.ts
@@ -1,4 +1,7 @@
-import { NewEnrollmentHistoryModel } from "@repo/common/models";
+import {
+  EnrollmentTimeframeModel,
+  NewEnrollmentHistoryModel,
+} from "@repo/common/models";
 
 import { Semester } from "../../generated-types/graphql";
 import { buildSubjectQuery } from "../../utils/subject";
@@ -85,43 +88,118 @@ function truncateAtWaitlistZeroCutoff(sorted: HistoryEntry[]): number {
 }
 
 /**
- * Count waitlist decreases and time span from a semester's history.
- * Only decreases in waitlistedCount count; increases count as 0 (not negative).
- * Stops counting once waitlist has been at 0 for WAITLIST_ZERO_CUTOFF_DAYS
- * (waitlist phase ended).
+ * Count waitlist decreases and the active-window length, measured only within
+ * the waitlist-relevant period:
+ *   - Drop any entries at/after the adjustment phase start (post-adjustment
+ *     waitlist data is noise — once classes start the waitlist is effectively
+ *     frozen/ignored, so including it would dilute the drop rate to ~0).
+ *   - Drop the leading run of entries with waitlistedCount === 0 (pre-enrollment
+ *     dead time) so those idle days don't dilute the drop rate.
+ *   - Stop once waitlist has been 0 for WAITLIST_ZERO_CUTOFF_DAYS (waitlist
+ *     phase ended naturally).
  */
-function waitlistDecreasesAndDaysFromHistory(history: HistoryEntry[]): {
-  waitlistDecreases: number;
-  days: number;
-} {
+function waitlistDecreasesAndDaysFromHistory(
+  history: HistoryEntry[],
+  adjustmentStartMs: number | null
+): { waitlistDecreases: number; days: number } {
   if (history.length === 0) return { waitlistDecreases: 0, days: 0 };
 
-  const sorted = [...history].sort(
+  let sorted = [...history].sort(
     (a, b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime()
   );
 
-  const lastIdx = truncateAtWaitlistZeroCutoff(sorted);
-  if (lastIdx < 0) return { waitlistDecreases: 0, days: 0 };
+  // Drop everything at/after the adjustment phase start. If the final kept
+  // entry straddles that boundary, clamp its endTime.
+  if (adjustmentStartMs !== null) {
+    sorted = sorted.filter(
+      (e) => new Date(e.startTime).getTime() < adjustmentStartMs
+    );
+    if (sorted.length === 0) return { waitlistDecreases: 0, days: 0 };
+
+    const last = sorted[sorted.length - 1];
+    if (new Date(last.endTime).getTime() > adjustmentStartMs) {
+      sorted[sorted.length - 1] = {
+        ...last,
+        endTime: new Date(adjustmentStartMs),
+      };
+    }
+  }
+
+  // Trim the leading zero-waitlist run: those are pre-waitlist-period days
+  // and dilute the per-day drop rate if counted.
+  const firstActiveIdx = sorted.findIndex(
+    (e) => (e.waitlistedCount ?? 0) > 0
+  );
+  if (firstActiveIdx === -1) {
+    return { waitlistDecreases: 0, days: 0 };
+  }
+  // Keep one entry before the first non-zero so the 0 -> N transition and
+  // the moment the waitlist opens are represented.
+  const windowStartIdx = Math.max(0, firstActiveIdx - 1);
+  const windowed = sorted.slice(windowStartIdx);
+
+  const lastIdx = truncateAtWaitlistZeroCutoff(windowed);
+  if (lastIdx <= 0) return { waitlistDecreases: 0, days: 0 };
 
   let waitlistDecreases = 0;
   for (let i = 1; i <= lastIdx; i++) {
-    const prev = sorted[i - 1].waitlistedCount ?? 0;
-    const curr = sorted[i].waitlistedCount ?? 0;
+    const prev = windowed[i - 1].waitlistedCount ?? 0;
+    const curr = windowed[i].waitlistedCount ?? 0;
     if (prev > curr) waitlistDecreases += prev - curr;
   }
 
-  const firstStart = new Date(sorted[0].startTime).getTime();
-  const lastEnd = new Date(sorted[lastIdx].endTime).getTime();
+  const firstStart = new Date(windowed[0].startTime).getTime();
+  const lastEnd = new Date(windowed[lastIdx].endTime).getTime();
   const days = Math.max(0, (lastEnd - firstStart) / MS_PER_DAY);
 
   return { waitlistDecreases, days };
 }
 
+/** Map (year, semester) -> earliest adjustment-phase start time (ms). */
+async function fetchAdjustmentStartMsByTerm(
+  terms: { year: number; semester: string }[]
+): Promise<Map<string, number>> {
+  const result = new Map<string, number>();
+  if (terms.length === 0) return result;
+
+  const uniqueTerms = Array.from(
+    new Map(
+      terms.map((t) => [`${t.year}-${t.semester}`, t] as const)
+    ).values()
+  );
+
+  const timeframes = await EnrollmentTimeframeModel.find({
+    isAdjustment: true,
+    $or: uniqueTerms.map((t) => ({ year: t.year, semester: t.semester })),
+  })
+    .select({ year: 1, semester: 1, startDate: 1 })
+    .lean();
+
+  for (const tf of timeframes) {
+    const key = `${tf.year}-${tf.semester}`;
+    const ms = new Date(tf.startDate).getTime();
+    const existing = result.get(key);
+    if (existing === undefined || ms < existing) {
+      result.set(key, ms);
+    }
+  }
+
+  return result;
+}
+
+export async function getAdjustmentStartMs(
+  year: number,
+  semester: string
+): Promise<number | null> {
+  const map = await fetchAdjustmentStartMsByTerm([{ year, semester }]);
+  return map.get(`${year}-${semester}`) ?? null;
+}
+
 /**
  * Estimate lambda (waitlist decreases per day) from a section's enrollment history
- * across the last 3 semesters. Uses consecutive history entries: decreases in
- * waitlistedCount count as waitlist decreases; increases count as 0.
- * Returns null if no history or not enough data.
+ * across the last 3 semesters, truncating each semester at the adjustment phase
+ * start (since waitlist activity past that point is effectively dead data).
+ * Returns null if no usable history.
  */
 export async function estimateLambdaFromEnrollmentHistory(
   section: WaitlistSectionInput
@@ -148,14 +226,24 @@ export async function estimateLambdaFromEnrollmentHistory(
 
   const lastN = sortedEnrollments.slice(0, SEMESTERS_FOR_LAMBDA_ESTIMATE);
 
+  const adjustmentStartByTerm = await fetchAdjustmentStartMsByTerm(
+    lastN.map((doc) => ({ year: doc.year, semester: doc.semester }))
+  );
+
   let totalWaitlistDecreases = 0;
   let totalDays = 0;
 
   for (const doc of lastN) {
     const history = (doc.history ?? []) as HistoryEntry[];
     if (history.length === 0) continue;
-    const { waitlistDecreases, days } =
-      waitlistDecreasesAndDaysFromHistory(history);
+
+    const adjustmentStartMs =
+      adjustmentStartByTerm.get(`${doc.year}-${doc.semester}`) ?? null;
+
+    const { waitlistDecreases, days } = waitlistDecreasesAndDaysFromHistory(
+      history,
+      adjustmentStartMs
+    );
     totalWaitlistDecreases += waitlistDecreases;
     totalDays += days;
   }

--- a/apps/backend/src/modules/waitlist/controller.ts
+++ b/apps/backend/src/modules/waitlist/controller.ts
@@ -127,9 +127,7 @@ function waitlistDecreasesAndDaysFromHistory(
 
   // Trim the leading zero-waitlist run: those are pre-waitlist-period days
   // and dilute the per-day drop rate if counted.
-  const firstActiveIdx = sorted.findIndex(
-    (e) => (e.waitlistedCount ?? 0) > 0
-  );
+  const firstActiveIdx = sorted.findIndex((e) => (e.waitlistedCount ?? 0) > 0);
   if (firstActiveIdx === -1) {
     return { waitlistDecreases: 0, days: 0 };
   }
@@ -163,9 +161,7 @@ async function fetchAdjustmentStartMsByTerm(
   if (terms.length === 0) return result;
 
   const uniqueTerms = Array.from(
-    new Map(
-      terms.map((t) => [`${t.year}-${t.semester}`, t] as const)
-    ).values()
+    new Map(terms.map((t) => [`${t.year}-${t.semester}`, t] as const)).values()
   );
 
   const timeframes = await EnrollmentTimeframeModel.find({

--- a/apps/backend/src/modules/waitlist/index.ts
+++ b/apps/backend/src/modules/waitlist/index.ts
@@ -1,0 +1,8 @@
+import { waitlistTypeDef } from "@repo/gql-typedefs";
+
+import resolver from "./resolver";
+
+export default {
+  resolver,
+  typeDef: waitlistTypeDef,
+};

--- a/apps/backend/src/modules/waitlist/resolver.ts
+++ b/apps/backend/src/modules/waitlist/resolver.ts
@@ -1,0 +1,54 @@
+import { GraphQLError } from "graphql";
+
+import {
+  estimateLambdaFromEnrollmentHistory,
+  getWaitlistGetInProbability,
+} from "./controller";
+import { WaitlistModule } from "./generated-types/module-types";
+
+const resolvers: WaitlistModule.Resolvers = {
+  Query: {
+    waitlistGetInProbability: async (
+      _,
+      { k, timeRemainingDays, lambda, section }
+    ) => {
+      if (k < 0) {
+        throw new GraphQLError("k must be non-negative", {
+          extensions: { code: "BAD_USER_INPUT" },
+        });
+      }
+      if (timeRemainingDays < 0) {
+        throw new GraphQLError("timeRemainingDays must be non-negative", {
+          extensions: { code: "BAD_USER_INPUT" },
+        });
+      }
+
+      let lambdaUsed: number | undefined = lambda ?? undefined;
+
+      if (lambdaUsed === undefined && section) {
+        const estimated = await estimateLambdaFromEnrollmentHistory({
+          year: section.year,
+          semester: section.semester,
+          sessionId: section.sessionId ?? null,
+          subject: section.subject,
+          courseNumber: section.courseNumber,
+          sectionNumber: section.sectionNumber,
+        });
+        if (estimated !== null) lambdaUsed = estimated;
+      }
+
+      const result = getWaitlistGetInProbability(
+        k,
+        timeRemainingDays,
+        lambdaUsed
+      );
+
+      return {
+        probability: result.probability,
+        lambdaUsed: result.lambdaUsed,
+      };
+    },
+  },
+};
+
+export default resolvers;

--- a/apps/backend/src/modules/waitlist/resolver.ts
+++ b/apps/backend/src/modules/waitlist/resolver.ts
@@ -22,6 +22,11 @@ const resolvers: WaitlistModule.Resolvers = {
           extensions: { code: "BAD_USER_INPUT" },
         });
       }
+      if (lambda !== undefined && lambda !== null && lambda < 0) {
+        throw new GraphQLError("lambda must be non-negative", {
+          extensions: { code: "BAD_USER_INPUT" },
+        });
+      }
 
       let lambdaUsed: number | undefined = lambda ?? undefined;
 

--- a/apps/backend/src/modules/waitlist/resolver.ts
+++ b/apps/backend/src/modules/waitlist/resolver.ts
@@ -2,9 +2,12 @@ import { GraphQLError } from "graphql";
 
 import {
   estimateLambdaFromEnrollmentHistory,
+  getAdjustmentStartMs,
   getWaitlistGetInProbability,
 } from "./controller";
 import { WaitlistModule } from "./generated-types/module-types";
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 const resolvers: WaitlistModule.Resolvers = {
   Query: {
@@ -29,22 +32,43 @@ const resolvers: WaitlistModule.Resolvers = {
       }
 
       let lambdaUsed: number | undefined = lambda ?? undefined;
+      let effectiveTimeRemainingDays = timeRemainingDays;
 
-      if (lambdaUsed === undefined && section) {
-        const estimated = await estimateLambdaFromEnrollmentHistory({
-          year: section.year,
-          semester: section.semester,
-          sessionId: section.sessionId ?? null,
-          subject: section.subject,
-          courseNumber: section.courseNumber,
-          sectionNumber: section.sectionNumber,
-        });
-        if (estimated !== null) lambdaUsed = estimated;
+      if (section) {
+        // Clamp the time horizon at the adjustment phase start: after classes
+        // begin the waitlist is effectively frozen, so that time shouldn't
+        // contribute to the expected number of drops.
+        const adjustmentStartMs = await getAdjustmentStartMs(
+          section.year,
+          section.semester
+        );
+        if (adjustmentStartMs !== null) {
+          const daysUntilAdjustment = Math.max(
+            0,
+            (adjustmentStartMs - Date.now()) / MS_PER_DAY
+          );
+          effectiveTimeRemainingDays = Math.min(
+            effectiveTimeRemainingDays,
+            daysUntilAdjustment
+          );
+        }
+
+        if (lambdaUsed === undefined) {
+          const estimated = await estimateLambdaFromEnrollmentHistory({
+            year: section.year,
+            semester: section.semester,
+            sessionId: section.sessionId ?? null,
+            subject: section.subject,
+            courseNumber: section.courseNumber,
+            sectionNumber: section.sectionNumber,
+          });
+          if (estimated !== null) lambdaUsed = estimated;
+        }
       }
 
       const result = getWaitlistGetInProbability(
         k,
-        timeRemainingDays,
+        effectiveTimeRemainingDays,
         lambdaUsed
       );
 

--- a/apps/frontend/src/app/Enrollment/EnrollmentGraph.tsx
+++ b/apps/frontend/src/app/Enrollment/EnrollmentGraph.tsx
@@ -76,6 +76,7 @@ const TOOLTIP_DATE_FORMATTER = new Intl.DateTimeFormat("en-US", {
 });
 
 const getSeriesKey = (index: number) => `enroll_${index}`;
+const getWaitlistSeriesKey = (index: number) => `waitlist_${index}`;
 const getCapacityKey = (index: number) => `capacity_${index}`;
 
 const getGradientId = (outputId: string) =>
@@ -187,6 +188,11 @@ export default function EnrollmentGraph({
               maxEnrollDenominator > 0
                 ? ((entry.enrolledCount ?? 0) / maxEnrollDenominator) * 100
                 : null,
+            waitlistedCount: entry.waitlistedCount ?? 0,
+            waitlistedPercent:
+              maxEnrollDenominator > 0
+                ? ((entry.waitlistedCount ?? 0) / maxEnrollDenominator) * 100
+                : null,
             capacityCount: maxEnroll,
             capacityPercent:
               maxEnrollDenominator > 0
@@ -245,6 +251,9 @@ export default function EnrollmentGraph({
           datum[getSeriesKey(outputIndex)] = showRawNumbers
             ? (point?.enrolledCount ?? null)
             : (point?.enrolledPercent ?? null);
+          datum[getWaitlistSeriesKey(outputIndex)] = showRawNumbers
+            ? (point?.waitlistedCount ?? null)
+            : (point?.waitlistedPercent ?? null);
           datum[getCapacityKey(outputIndex)] = showRawNumbers
             ? (point?.capacityCount ?? null)
             : (point?.capacityPercent ?? null);
@@ -258,6 +267,23 @@ export default function EnrollmentGraph({
     () =>
       outputs.map((_, outputIndex) => {
         const seriesKey = getSeriesKey(outputIndex);
+        return chartData.reduce<SeriesPoint[]>((points, datum) => {
+          const value = datum[seriesKey];
+          if (typeof value === "number") {
+            points.push({
+              timeDelta: datum.timeDelta,
+              value,
+            });
+          }
+          return points;
+        }, []);
+      }),
+    [chartData, outputs]
+  );
+  const waitlistSeriesPointsByOutput = useMemo(
+    () =>
+      outputs.map((_, outputIndex) => {
+        const seriesKey = getWaitlistSeriesKey(outputIndex);
         return chartData.reduce<SeriesPoint[]>((points, datum) => {
           const value = datum[seriesKey];
           if (typeof value === "number") {
@@ -612,8 +638,9 @@ export default function EnrollmentGraph({
               });
 
               const rows = outputs
-                .map((output, outputIndex) => {
+                .flatMap((output, outputIndex) => {
                   const seriesKey = getSeriesKey(outputIndex);
+                  const waitlistSeriesKey = getWaitlistSeriesKey(outputIndex);
                   const exactValue = payloadValuesBySeriesKey.get(seriesKey);
                   const interpolatedValue =
                     typeof exactValue === "number"
@@ -622,15 +649,42 @@ export default function EnrollmentGraph({
                           seriesPointsByOutput[outputIndex] ?? [],
                           labelMinutes
                         );
+                  const exactWaitlistValue =
+                    payloadValuesBySeriesKey.get(waitlistSeriesKey);
+                  const interpolatedWaitlistValue =
+                    typeof exactWaitlistValue === "number"
+                      ? exactWaitlistValue
+                      : estimateSeriesValueAtTime(
+                          waitlistSeriesPointsByOutput[outputIndex] ?? [],
+                          labelMinutes
+                        );
 
-                  if (typeof interpolatedValue !== "number") return null;
+                  const outputRows: Array<{
+                    key: string;
+                    label: string;
+                    value: number;
+                    color: string;
+                  }> = [];
 
-                  return {
-                    key: `${seriesKey}-${output.id}`,
-                    label: getDisplayLabel(output),
-                    value: interpolatedValue,
-                    color: output.color,
-                  };
+                  if (typeof interpolatedValue === "number") {
+                    outputRows.push({
+                      key: `${seriesKey}-${output.id}`,
+                      label: getDisplayLabel(output),
+                      value: interpolatedValue,
+                      color: output.color,
+                    });
+                  }
+
+                  if (typeof interpolatedWaitlistValue === "number") {
+                    outputRows.push({
+                      key: `${waitlistSeriesKey}-${output.id}`,
+                      label: `${getDisplayLabel(output)} (waitlist)`,
+                      value: interpolatedWaitlistValue,
+                      color: output.color,
+                    });
+                  }
+
+                  return outputRows;
                 })
                 .filter(
                   (
@@ -789,6 +843,28 @@ export default function EnrollmentGraph({
                   animationDuration={SERIES_ANIMATION_DURATION_MS}
                   animationEasing="ease-out"
                 />
+                <Line
+                  dataKey={getWaitlistSeriesKey(outputIndex)}
+                  stroke={
+                    isDimmed ? "var(--border-color)" : output.color
+                  }
+                  strokeOpacity={isDimmed ? 1 : 0.75}
+                  strokeWidth={isDimmed ? 1.5 : 2}
+                  strokeDasharray="6 4"
+                  dot={false}
+                  activeDot={{
+                    r: 4,
+                    fill: dotColor,
+                    stroke: "var(--foreground-color)",
+                    strokeWidth: 1.25,
+                  }}
+                  type="monotone"
+                  connectNulls
+                  isAnimationActive={shouldAnimateSeries}
+                  animationBegin={0}
+                  animationDuration={SERIES_ANIMATION_DURATION_MS}
+                  animationEasing="ease-out"
+                />
               </Fragment>
             );
           })}
@@ -809,6 +885,7 @@ export default function EnrollmentGraph({
       firstTime,
       capacityChangeEventsByOutput,
       seriesPointsByOutput,
+      waitlistSeriesPointsByOutput,
       showCapacityTooltip,
       hideCapacityTooltip,
     ]

--- a/apps/frontend/src/app/Enrollment/EnrollmentGraph.tsx
+++ b/apps/frontend/src/app/Enrollment/EnrollmentGraph.tsx
@@ -845,9 +845,7 @@ export default function EnrollmentGraph({
                 />
                 <Line
                   dataKey={getWaitlistSeriesKey(outputIndex)}
-                  stroke={
-                    isDimmed ? "var(--border-color)" : output.color
-                  }
+                  stroke={isDimmed ? "var(--border-color)" : output.color}
                   strokeOpacity={isDimmed ? 1 : 0.75}
                   strokeWidth={isDimmed ? 1.5 : 2}
                   strokeDasharray="6 4"

--- a/apps/frontend/src/app/Enrollment/EnrollmentGraph.utils.test.ts
+++ b/apps/frontend/src/app/Enrollment/EnrollmentGraph.utils.test.ts
@@ -212,6 +212,8 @@ describe("areOutputsFromSameSemester", () => {
 const ep = (enrolled: number, capacity: number): EnrollmentPoint => ({
   enrolledCount: enrolled,
   enrolledPercent: null,
+  waitlistedCount: 0,
+  waitlistedPercent: null,
   capacityCount: capacity,
   capacityPercent: null,
 });

--- a/apps/frontend/src/app/Enrollment/EnrollmentGraph.utils.ts
+++ b/apps/frontend/src/app/Enrollment/EnrollmentGraph.utils.ts
@@ -115,6 +115,8 @@ export const getCapacityChangeTimeDeltas = (
 export interface EnrollmentPoint {
   enrolledCount: number | null;
   enrolledPercent: number | null;
+  waitlistedCount: number | null;
+  waitlistedPercent: number | null;
   capacityCount: number | null;
   capacityPercent: number | null;
 }
@@ -210,6 +212,8 @@ export const interpolateEnrollmentPoint = (
   return {
     enrolledCount: lerp(prev.enrolledCount, next.enrolledCount),
     enrolledPercent: lerp(prev.enrolledPercent, next.enrolledPercent),
+    waitlistedCount: lerp(prev.waitlistedCount, next.waitlistedCount),
+    waitlistedPercent: lerp(prev.waitlistedPercent, next.waitlistedPercent),
     capacityCount: lerp(prev.capacityCount, next.capacityCount),
     capacityPercent: lerp(prev.capacityPercent, next.capacityPercent),
   };
@@ -219,7 +223,9 @@ const enrollmentPointsEqual = (
   a: EnrollmentPoint,
   b: EnrollmentPoint
 ): boolean =>
-  a.enrolledCount === b.enrolledCount && a.capacityCount === b.capacityCount;
+  a.enrolledCount === b.enrolledCount &&
+  a.waitlistedCount === b.waitlistedCount &&
+  a.capacityCount === b.capacityCount;
 
 /**
  * Remove interior points of constant-value runs, keeping only boundary points.

--- a/apps/frontend/src/app/Enrollment/WaitlistProbability.tsx
+++ b/apps/frontend/src/app/Enrollment/WaitlistProbability.tsx
@@ -1,0 +1,104 @@
+import { useState } from "react";
+
+import { useQuery } from "@apollo/client/react";
+
+import { Input, Text } from "@repo/theme";
+
+import { CourseAnalyticsField, CourseAnalyticsGraphBox } from "@/components/CourseAnalytics/CourseAnalyticsLayout";
+import { GetWaitlistProbabilityDocument } from "@/lib/generated/graphql";
+import type { Semester } from "@/lib/generated/graphql";
+
+interface WaitlistProbabilityProps {
+  year: number;
+  semester: Semester;
+  sessionId: string | null;
+  subject: string;
+  courseNumber: string;
+  sectionNumber: string;
+}
+
+export function WaitlistProbability({
+  year,
+  semester,
+  sessionId,
+  subject,
+  courseNumber,
+  sectionNumber,
+}: WaitlistProbabilityProps) {
+  const [kStr, setKStr] = useState("1");
+  const [timeRemainingDaysStr, setTimeRemainingDaysStr] = useState("7");
+
+  const section = {
+    year,
+    semester,
+    sessionId: sessionId ?? null,
+    subject,
+    courseNumber,
+    sectionNumber,
+  };
+
+  const kNum = kStr === "" ? NaN : Number(kStr);
+  const timeRemainingDaysNum =
+    timeRemainingDaysStr === "" ? NaN : Number(timeRemainingDaysStr);
+  const hasValidInput =
+    !Number.isNaN(kNum) &&
+    !Number.isNaN(timeRemainingDaysNum) &&
+    kNum >= 0 &&
+    timeRemainingDaysNum >= 0;
+
+  const { data, loading, error } = useQuery(GetWaitlistProbabilityDocument, {
+    variables: {
+      k: Math.max(0, Math.floor(kNum)),
+      timeRemainingDays: Math.max(0, timeRemainingDaysNum),
+      section,
+    },
+    skip: !hasValidInput,
+  });
+
+  const result = hasValidInput ? data?.waitlistGetInProbability : null;
+
+  return (
+    <CourseAnalyticsGraphBox>
+      <Text size="2" weight="medium" style={{ marginBottom: 12 }}>
+        Waitlist get-in probability
+      </Text>
+      <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+        <CourseAnalyticsField label="Position">
+          <Input
+            type="number"
+            min={0}
+            value={kStr}
+            onChange={(e) => setKStr(e.target.value)}
+          />
+        </CourseAnalyticsField>
+        <CourseAnalyticsField label="Days left">
+          <Input
+            type="number"
+            min={0}
+            step={0.5}
+            value={timeRemainingDaysStr}
+            onChange={(e) => setTimeRemainingDaysStr(e.target.value)}
+          />
+        </CourseAnalyticsField>
+      </div>
+      {loading && hasValidInput && (
+        <Text size="1" style={{ color: "var(--paragraph-color)", marginTop: 8 }}>
+          Calculating…
+        </Text>
+      )}
+      {error && (
+        <Text size="1" style={{ color: "var(--red-500)", marginTop: 8 }}>
+          {error.message}
+        </Text>
+      )}
+      {result && !loading && hasValidInput && (
+        <div style={{ display: "flex", flexDirection: "column", gap: 4, marginTop: 12 }}>
+          <Text size="2">
+            P(get in) ={" "}
+            <strong>{(result.probability * 100).toFixed(1)}%</strong>
+          </Text>
+        </div>
+      )}
+    </CourseAnalyticsGraphBox>
+  );
+}

--- a/apps/frontend/src/app/Enrollment/WaitlistProbability.tsx
+++ b/apps/frontend/src/app/Enrollment/WaitlistProbability.tsx
@@ -4,7 +4,10 @@ import { useQuery } from "@apollo/client/react";
 
 import { Input, Text } from "@repo/theme";
 
-import { CourseAnalyticsField, CourseAnalyticsGraphBox } from "@/components/CourseAnalytics/CourseAnalyticsLayout";
+import {
+  CourseAnalyticsField,
+  CourseAnalyticsGraphBox,
+} from "@/components/CourseAnalytics/CourseAnalyticsLayout";
 import { GetWaitlistProbabilityDocument } from "@/lib/generated/graphql";
 import type { Semester } from "@/lib/generated/graphql";
 
@@ -82,7 +85,10 @@ export function WaitlistProbability({
         </CourseAnalyticsField>
       </div>
       {loading && hasValidInput && (
-        <Text size="1" style={{ color: "var(--paragraph-color)", marginTop: 8 }}>
+        <Text
+          size="1"
+          style={{ color: "var(--paragraph-color)", marginTop: 8 }}
+        >
           Calculating…
         </Text>
       )}
@@ -92,7 +98,14 @@ export function WaitlistProbability({
         </Text>
       )}
       {result && !loading && hasValidInput && (
-        <div style={{ display: "flex", flexDirection: "column", gap: 4, marginTop: 12 }}>
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 4,
+            marginTop: 12,
+          }}
+        >
           <Text size="2">
             P(get in) ={" "}
             <strong>{(result.probability * 100).toFixed(1)}%</strong>

--- a/apps/frontend/src/app/Enrollment/WaitlistProbability.tsx
+++ b/apps/frontend/src/app/Enrollment/WaitlistProbability.tsx
@@ -35,7 +35,11 @@ const parseDateInputToMs = (value: string): number | null => {
   const year = Number(yearStr);
   const month = Number(monthStr);
   const day = Number(dayStr);
-  if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(day))
+  if (
+    !Number.isFinite(year) ||
+    !Number.isFinite(month) ||
+    !Number.isFinite(day)
+  )
     return null;
 
   const localDate = new Date(year, month - 1, day, 12, 0, 0, 0);
@@ -97,17 +101,20 @@ export function WaitlistProbability({
       skip: isSummerSession,
     });
 
-  const { data: classDatesData } = useQuery(GetClassPrimarySectionDatesDocument, {
-    variables: {
-      year,
-      semester,
-      sessionId: sessionId ?? "1",
-      subject,
-      courseNumber,
-      number: sectionNumber,
-    },
-    skip: isSummerSession,
-  });
+  const { data: classDatesData } = useQuery(
+    GetClassPrimarySectionDatesDocument,
+    {
+      variables: {
+        year,
+        semester,
+        sessionId: sessionId ?? "1",
+        subject,
+        courseNumber,
+        number: sectionNumber,
+      },
+      skip: isSummerSession,
+    }
+  );
 
   const classStartDateRaw =
     classDatesData?.class?.primarySection?.startDate ?? null;
@@ -127,7 +134,8 @@ export function WaitlistProbability({
 
   const isInWaitlistPeriod = useMemo(() => {
     if (isSummerSession || viewingDateMs === null) return false;
-    if (!enrollmentTimeframes || enrollmentTimeframes.length === 0) return false;
+    if (!enrollmentTimeframes || enrollmentTimeframes.length === 0)
+      return false;
 
     const timeframeMs = enrollmentTimeframes
       .map((timeframe) => {
@@ -166,8 +174,10 @@ export function WaitlistProbability({
   });
 
   const result =
-    hasValidInput && shouldShowPredictor ? data?.waitlistGetInProbability : null;
-  const probability = isInstantGetIn ? 1 : result?.probability ?? null;
+    hasValidInput && shouldShowPredictor
+      ? data?.waitlistGetInProbability
+      : null;
+  const probability = isInstantGetIn ? 1 : (result?.probability ?? null);
   const predictorTargetLabel =
     courseLabel ?? `${subject} ${courseNumber} (Section ${sectionNumber})`;
 
@@ -183,106 +193,105 @@ export function WaitlistProbability({
   return (
     <div style={{ marginTop: 24 }}>
       <CourseAnalyticsGraphBox>
-      <div style={{ marginBottom: 10 }}>
-        <Text size="2" weight="medium">
-          Waitlist predictor
-        </Text>
-        <Text size="1" style={{ color: "var(--paragraph-color)" }}>
-          For: {predictorTargetLabel}
-        </Text>
-        <Text
-          size="1"
-          style={{ color: "var(--paragraph-color)", marginTop: 4 }}
-        >
-          Probability to get off waitlist by class start date.
-        </Text>
-      </div>
+        <div style={{ marginBottom: 10 }}>
+          <Text size="2" weight="medium">
+            Waitlist predictor
+          </Text>
+          <Text size="1" style={{ color: "var(--paragraph-color)" }}>
+            For: {predictorTargetLabel}
+          </Text>
+          <Text
+            size="1"
+            style={{ color: "var(--paragraph-color)", marginTop: 4 }}
+          >
+            Probability to get off waitlist by class start date.
+          </Text>
+        </div>
 
-      <Text size="2" weight="medium" style={{ marginBottom: 12 }}>
-        Get-in probability
-      </Text>
-      <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
-        <CourseAnalyticsField label="Position">
+        <Text size="2" weight="medium" style={{ marginBottom: 12 }}>
+          Get-in probability
+        </Text>
+        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+          <CourseAnalyticsField label="Position">
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 8,
+                flexWrap: "nowrap",
+              }}
+            >
+              <Input
+                type="number"
+                min={0}
+                value={kStr}
+                onChange={(e) => setKStr(e.target.value)}
+                style={{
+                  width: 72,
+                  minWidth: 72,
+                  maxWidth: 72,
+                  flex: "0 0 72px",
+                }}
+              />
+              {waitlistSuffix && (
+                <Text
+                  size="2"
+                  style={{
+                    color: "var(--label-color)",
+                    whiteSpace: "nowrap",
+                    flex: "0 0 auto",
+                  }}
+                >
+                  {waitlistSuffix}
+                </Text>
+              )}
+            </div>
+          </CourseAnalyticsField>
+          <CourseAnalyticsField label="Days until class start">
+            <Text size="2" style={{ color: "var(--paragraph-color)" }}>
+              {timeRemainingDaysNum !== null
+                ? (() => {
+                    const rounded = Math.round(timeRemainingDaysNum);
+                    return `${rounded} day${rounded === 1 ? "" : "s"}`;
+                  })()
+                : "Unknown"}
+            </Text>
+          </CourseAnalyticsField>
+        </div>
+
+        {loading && hasValidInput && !isInstantGetIn && (
+          <Text
+            size="1"
+            style={{ color: "var(--paragraph-color)", marginTop: 8 }}
+          >
+            Calculating…
+          </Text>
+        )}
+        {error && (
+          <Text size="1" style={{ color: "var(--red-500)", marginTop: 8 }}>
+            {error.message}
+          </Text>
+        )}
+        {probability !== null && !loading && hasValidInput && (
           <div
             style={{
               display: "flex",
-              alignItems: "center",
-              gap: 8,
-              flexWrap: "nowrap",
+              flexDirection: "column",
+              gap: 4,
+              marginTop: 12,
             }}
           >
-            <Input
-              type="number"
-              min={0}
-              value={kStr}
-              onChange={(e) => setKStr(e.target.value)}
-              style={{
-                width: 72,
-                minWidth: 72,
-                maxWidth: 72,
-                flex: "0 0 72px",
-              }}
-            />
-            {waitlistSuffix && (
-              <Text
-                size="2"
-                style={{
-                  color: "var(--label-color)",
-                  whiteSpace: "nowrap",
-                  flex: "0 0 auto",
-                }}
-              >
-                {waitlistSuffix}
+            <Text size="2">
+              P(get in) = <strong>{(probability * 100).toFixed(1)}%</strong>
+            </Text>
+            {isInstantGetIn && (
+              <Text size="1" style={{ color: "var(--paragraph-color)" }}>
+                Current waitlist is 0, so this is treated as an instant get-in.
               </Text>
             )}
           </div>
-        </CourseAnalyticsField>
-        <CourseAnalyticsField label="Days until class start">
-          <Text size="2" style={{ color: "var(--paragraph-color)" }}>
-            {timeRemainingDaysNum !== null
-              ? (() => {
-                  const rounded = Math.round(timeRemainingDaysNum);
-                  return `${rounded} day${rounded === 1 ? "" : "s"}`;
-                })()
-              : "Unknown"}
-          </Text>
-        </CourseAnalyticsField>
-      </div>
-
-      {loading && hasValidInput && !isInstantGetIn && (
-        <Text
-          size="1"
-          style={{ color: "var(--paragraph-color)", marginTop: 8 }}
-        >
-          Calculating…
-        </Text>
-      )}
-      {error && (
-        <Text size="1" style={{ color: "var(--red-500)", marginTop: 8 }}>
-          {error.message}
-        </Text>
-      )}
-      {probability !== null && !loading && hasValidInput && (
-        <div
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            gap: 4,
-            marginTop: 12,
-          }}
-        >
-          <Text size="2">
-            P(get in) ={" "}
-            <strong>{(probability * 100).toFixed(1)}%</strong>
-          </Text>
-          {isInstantGetIn && (
-            <Text size="1" style={{ color: "var(--paragraph-color)" }}>
-              Current waitlist is 0, so this is treated as an instant get-in.
-            </Text>
-          )}
-        </div>
-      )}
-    </CourseAnalyticsGraphBox>
+        )}
+      </CourseAnalyticsGraphBox>
     </div>
   );
 }

--- a/apps/frontend/src/app/Enrollment/WaitlistProbability.tsx
+++ b/apps/frontend/src/app/Enrollment/WaitlistProbability.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
 import { useQuery } from "@apollo/client/react";
 
@@ -8,8 +8,13 @@ import {
   CourseAnalyticsField,
   CourseAnalyticsGraphBox,
 } from "@/components/CourseAnalytics/CourseAnalyticsLayout";
-import { GetWaitlistProbabilityDocument } from "@/lib/generated/graphql";
+import { useReadEnrollmentTimeframes } from "@/hooks/api/enrollment";
+import {
+  GetClassPrimarySectionDatesDocument,
+  GetWaitlistProbabilityDocument,
+} from "@/lib/generated/graphql";
 import type { Semester } from "@/lib/generated/graphql";
+import { Semester as SemesterEnum } from "@/lib/generated/graphql";
 
 interface WaitlistProbabilityProps {
   year: number;
@@ -18,7 +23,46 @@ interface WaitlistProbabilityProps {
   subject: string;
   courseNumber: string;
   sectionNumber: string;
+  currentWaitlistedCount?: number | null;
+  courseLabel?: string;
 }
+
+const MS_PER_DAY = 1000 * 60 * 60 * 24;
+
+const parseDateInputToMs = (value: string): number | null => {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return null;
+  const [yearStr, monthStr, dayStr] = value.split("-");
+  const year = Number(yearStr);
+  const month = Number(monthStr);
+  const day = Number(dayStr);
+  if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(day))
+    return null;
+
+  const localDate = new Date(year, month - 1, day, 12, 0, 0, 0);
+  const ms = localDate.getTime();
+  return Number.isNaN(ms) ? null : ms;
+};
+
+/** Calendar day at local noon from API date strings (ISO or YYYY-MM-DD). */
+const parseApiDateToLocalNoonMs = (value: string): number | null => {
+  const trimmed = value.trim();
+  const ymd = trimmed.match(/^(\d{4})-(\d{2})-(\d{2})/);
+  if (ymd) return parseDateInputToMs(`${ymd[1]}-${ymd[2]}-${ymd[3]}`);
+
+  const parsed = Date.parse(trimmed);
+  if (Number.isNaN(parsed)) return null;
+  const d = new Date(parsed);
+  return parseDateInputToMs(
+    `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`
+  );
+};
+
+const getTodayLocalNoonMs = (): number | null => {
+  const now = new Date();
+  return parseDateInputToMs(
+    `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`
+  );
+};
 
 export function WaitlistProbability({
   year,
@@ -27,9 +71,12 @@ export function WaitlistProbability({
   subject,
   courseNumber,
   sectionNumber,
+  currentWaitlistedCount = null,
+  courseLabel,
 }: WaitlistProbabilityProps) {
   const [kStr, setKStr] = useState("1");
-  const [timeRemainingDaysStr, setTimeRemainingDaysStr] = useState("7");
+
+  const viewingDateMs = getTodayLocalNoonMs();
 
   const section = {
     year,
@@ -41,50 +88,168 @@ export function WaitlistProbability({
   };
 
   const kNum = kStr === "" ? NaN : Number(kStr);
-  const timeRemainingDaysNum =
-    timeRemainingDaysStr === "" ? NaN : Number(timeRemainingDaysStr);
+
+  const isSummerSession = semester === SemesterEnum.Summer;
+  const isInstantGetIn = currentWaitlistedCount === 0;
+
+  const { data: enrollmentTimeframes, loading: loadingTimeframes } =
+    useReadEnrollmentTimeframes(year, semester, {
+      skip: isSummerSession,
+    });
+
+  const { data: classDatesData } = useQuery(GetClassPrimarySectionDatesDocument, {
+    variables: {
+      year,
+      semester,
+      sessionId: sessionId ?? "1",
+      subject,
+      courseNumber,
+      number: sectionNumber,
+    },
+    skip: isSummerSession,
+  });
+
+  const classStartDateRaw =
+    classDatesData?.class?.primarySection?.startDate ?? null;
+
+  const timeRemainingDaysNum = useMemo<number | null>(() => {
+    if (!classStartDateRaw || viewingDateMs === null) return null;
+    const classStartMs = parseApiDateToLocalNoonMs(classStartDateRaw);
+    if (classStartMs === null) return null;
+    return Math.max(0, (classStartMs - viewingDateMs) / MS_PER_DAY);
+  }, [classStartDateRaw, viewingDateMs]);
+
   const hasValidInput =
     !Number.isNaN(kNum) &&
-    !Number.isNaN(timeRemainingDaysNum) &&
     kNum >= 0 &&
-    timeRemainingDaysNum >= 0;
+    timeRemainingDaysNum !== null &&
+    Number.isFinite(timeRemainingDaysNum);
+
+  const isInWaitlistPeriod = useMemo(() => {
+    if (isSummerSession || viewingDateMs === null) return false;
+    if (!enrollmentTimeframes || enrollmentTimeframes.length === 0) return false;
+
+    const timeframeMs = enrollmentTimeframes
+      .map((timeframe) => {
+        const startMs = Date.parse(timeframe.startDate);
+        const endMs = timeframe.endDate ? Date.parse(timeframe.endDate) : NaN;
+        return {
+          startMs,
+          endMs: Number.isNaN(endMs) ? startMs : endMs,
+        };
+      })
+      .filter(
+        (timeframe) =>
+          Number.isFinite(timeframe.startMs) && Number.isFinite(timeframe.endMs)
+      );
+
+    if (timeframeMs.length === 0) return false;
+
+    const windowStart = Math.min(...timeframeMs.map((t) => t.startMs));
+    const windowEnd = Math.max(...timeframeMs.map((t) => t.endMs));
+    return viewingDateMs >= windowStart && viewingDateMs <= windowEnd;
+  }, [enrollmentTimeframes, isSummerSession, viewingDateMs]);
+
+  const shouldShowPredictor =
+    !isSummerSession &&
+    !loadingTimeframes &&
+    viewingDateMs !== null &&
+    isInWaitlistPeriod;
 
   const { data, loading, error } = useQuery(GetWaitlistProbabilityDocument, {
     variables: {
       k: Math.max(0, Math.floor(kNum)),
-      timeRemainingDays: Math.max(0, timeRemainingDaysNum),
+      timeRemainingDays: Math.max(0, timeRemainingDaysNum ?? 0),
       section,
     },
-    skip: !hasValidInput,
+    skip: !hasValidInput || !shouldShowPredictor || isInstantGetIn,
   });
 
-  const result = hasValidInput ? data?.waitlistGetInProbability : null;
+  const result =
+    hasValidInput && shouldShowPredictor ? data?.waitlistGetInProbability : null;
+  const probability = isInstantGetIn ? 1 : result?.probability ?? null;
+  const predictorTargetLabel =
+    courseLabel ?? `${subject} ${courseNumber} (Section ${sectionNumber})`;
+
+  const waitlistSuffix =
+    typeof currentWaitlistedCount === "number"
+      ? `/${currentWaitlistedCount}`
+      : null;
+
+  if (!shouldShowPredictor) {
+    return null;
+  }
 
   return (
-    <CourseAnalyticsGraphBox>
+    <div style={{ marginTop: 24 }}>
+      <CourseAnalyticsGraphBox>
+      <div style={{ marginBottom: 10 }}>
+        <Text size="2" weight="medium">
+          Waitlist predictor
+        </Text>
+        <Text size="1" style={{ color: "var(--paragraph-color)" }}>
+          For: {predictorTargetLabel}
+        </Text>
+        <Text
+          size="1"
+          style={{ color: "var(--paragraph-color)", marginTop: 4 }}
+        >
+          Probability to get off waitlist by class start date.
+        </Text>
+      </div>
+
       <Text size="2" weight="medium" style={{ marginBottom: 12 }}>
-        Waitlist get-in probability
+        Get-in probability
       </Text>
       <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
         <CourseAnalyticsField label="Position">
-          <Input
-            type="number"
-            min={0}
-            value={kStr}
-            onChange={(e) => setKStr(e.target.value)}
-          />
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+              flexWrap: "nowrap",
+            }}
+          >
+            <Input
+              type="number"
+              min={0}
+              value={kStr}
+              onChange={(e) => setKStr(e.target.value)}
+              style={{
+                width: 72,
+                minWidth: 72,
+                maxWidth: 72,
+                flex: "0 0 72px",
+              }}
+            />
+            {waitlistSuffix && (
+              <Text
+                size="2"
+                style={{
+                  color: "var(--label-color)",
+                  whiteSpace: "nowrap",
+                  flex: "0 0 auto",
+                }}
+              >
+                {waitlistSuffix}
+              </Text>
+            )}
+          </div>
         </CourseAnalyticsField>
-        <CourseAnalyticsField label="Days left">
-          <Input
-            type="number"
-            min={0}
-            step={0.5}
-            value={timeRemainingDaysStr}
-            onChange={(e) => setTimeRemainingDaysStr(e.target.value)}
-          />
+        <CourseAnalyticsField label="Days until class start">
+          <Text size="2" style={{ color: "var(--paragraph-color)" }}>
+            {timeRemainingDaysNum !== null
+              ? (() => {
+                  const rounded = Math.round(timeRemainingDaysNum);
+                  return `${rounded} day${rounded === 1 ? "" : "s"}`;
+                })()
+              : "Unknown"}
+          </Text>
         </CourseAnalyticsField>
       </div>
-      {loading && hasValidInput && (
+
+      {loading && hasValidInput && !isInstantGetIn && (
         <Text
           size="1"
           style={{ color: "var(--paragraph-color)", marginTop: 8 }}
@@ -97,7 +262,7 @@ export function WaitlistProbability({
           {error.message}
         </Text>
       )}
-      {result && !loading && hasValidInput && (
+      {probability !== null && !loading && hasValidInput && (
         <div
           style={{
             display: "flex",
@@ -108,10 +273,16 @@ export function WaitlistProbability({
         >
           <Text size="2">
             P(get in) ={" "}
-            <strong>{(result.probability * 100).toFixed(1)}%</strong>
+            <strong>{(probability * 100).toFixed(1)}%</strong>
           </Text>
+          {isInstantGetIn && (
+            <Text size="1" style={{ color: "var(--paragraph-color)" }}>
+              Current waitlist is 0, so this is treated as an instant get-in.
+            </Text>
+          )}
         </div>
       )}
     </CourseAnalyticsGraphBox>
+    </div>
   );
 }

--- a/apps/frontend/src/app/Enrollment/index.tsx
+++ b/apps/frontend/src/app/Enrollment/index.tsx
@@ -34,6 +34,7 @@ import { RecentType, addRecent, getPageUrl, savePageUrl } from "@/lib/recent";
 
 import styles from "./Enrollment.module.scss";
 import EnrollmentGraph from "./EnrollmentGraph";
+import { WaitlistProbability } from "./WaitlistProbability";
 
 interface SemesterSelection {
   year: number;
@@ -697,6 +698,16 @@ function EnrollmentVisualization({
         </CourseAnalyticsCardGrid>
       </div>
       <EnrollmentGraph outputs={outputs} hoveredIndex={hoveredIndex} />
+      {outputs.length >= 1 && (
+        <WaitlistProbability
+          year={outputs[0].input.year}
+          semester={outputs[0].input.semester}
+          sessionId={outputs[0].input.sessionId ?? null}
+          subject={outputs[0].input.subject}
+          courseNumber={outputs[0].input.courseNumber}
+          sectionNumber={outputs[0].input.sectionNumber}
+        />
+      )}
     </>
   );
 }

--- a/apps/frontend/src/app/Enrollment/index.tsx
+++ b/apps/frontend/src/app/Enrollment/index.tsx
@@ -638,6 +638,19 @@ function EnrollmentVisualization({
   const { hoveredIndex, hoverCard, clearHover, shiftAfterRemoval } =
     useRafHoverIndex();
   const shouldDimOthers = hoveredIndex !== null && outputs.length > 1;
+  const currentWaitlistedCount = useMemo(() => {
+    const history = outputs[0]?.data?.history ?? [];
+    if (history.length === 0) return null;
+
+    const latestEntry = history.reduce((latest, entry) => {
+      if (!latest) return entry;
+      return Date.parse(entry.endTime) > Date.parse(latest.endTime)
+        ? entry
+        : latest;
+    }, history[0]);
+
+    return latestEntry?.waitlistedCount ?? null;
+  }, [outputs]);
 
   const handleRemove = useCallback(
     (index: number) => {
@@ -706,6 +719,8 @@ function EnrollmentVisualization({
           subject={outputs[0].input.subject}
           courseNumber={outputs[0].input.courseNumber}
           sectionNumber={outputs[0].input.sectionNumber}
+          currentWaitlistedCount={currentWaitlistedCount}
+          courseLabel={`${outputs[0].course.subject} ${outputs[0].course.number} (Section ${outputs[0].input.sectionNumber})`}
         />
       )}
     </>

--- a/apps/frontend/src/components/Class/Enrollment/index.tsx
+++ b/apps/frontend/src/components/Class/Enrollment/index.tsx
@@ -26,6 +26,7 @@ import {
   getTimeDeltaKey,
   interpolateEnrollmentPoint,
 } from "@/app/Enrollment/EnrollmentGraph.utils";
+import { WaitlistProbability } from "@/app/Enrollment/WaitlistProbability";
 import {
   CapacityChangeMarker,
   ChartContainer,
@@ -38,8 +39,6 @@ import { useGetClassEnrollment } from "@/hooks/api/classes/useGetClass";
 import { useReadEnrollmentTimeframes } from "@/hooks/api/enrollment";
 import useClass from "@/hooks/useClass";
 import { getEnrollmentInputSearchParam } from "@/lib/enrollmentUrl";
-
-import { WaitlistProbability } from "@/app/Enrollment/WaitlistProbability";
 
 import styles from "./Enrollment.module.scss";
 

--- a/apps/frontend/src/components/Class/Enrollment/index.tsx
+++ b/apps/frontend/src/components/Class/Enrollment/index.tsx
@@ -39,6 +39,8 @@ import { useReadEnrollmentTimeframes } from "@/hooks/api/enrollment";
 import useClass from "@/hooks/useClass";
 import { getEnrollmentInputSearchParam } from "@/lib/enrollmentUrl";
 
+import { WaitlistProbability } from "@/app/Enrollment/WaitlistProbability";
+
 import styles from "./Enrollment.module.scss";
 
 const timeFormatter = new Intl.DateTimeFormat("en-US", {
@@ -487,6 +489,16 @@ export default function Enrollment() {
         </ChartContainer>
         <p className={styles.axisLabel}>Days since enrollment opened</p>
         {capacityTooltipElement}
+      </div>
+      <div style={{ marginTop: 24 }}>
+        <WaitlistProbability
+          year={_class.year}
+          semester={_class.semester}
+          sessionId={_class.sessionId ?? null}
+          subject={_class.subject}
+          courseNumber={_class.courseNumber}
+          sectionNumber={_class.number}
+        />
       </div>
     </ClassChartBox>
   );

--- a/apps/frontend/src/components/Class/Enrollment/index.tsx
+++ b/apps/frontend/src/components/Class/Enrollment/index.tsx
@@ -107,6 +107,13 @@ export default function Enrollment() {
   } = useCapacityChangeTooltip(chartRef);
 
   const history = enrollmentData?.primarySection?.enrollment?.history ?? [];
+  const currentWaitlistedCount = useMemo(() => {
+    if (history.length === 0) return null;
+    const latestEntry = history.reduce((latest, entry) =>
+      Date.parse(entry.endTime) > Date.parse(latest.endTime) ? entry : latest
+    );
+    return latestEntry.waitlistedCount ?? null;
+  }, [history]);
 
   const data = useMemo(() => {
     if (history.length === 0) return [];
@@ -136,6 +143,11 @@ export default function Enrollment() {
           enrolledPercent:
             maxEnrollDenominator > 0
               ? ((entry.enrolledCount ?? 0) / maxEnrollDenominator) * 100
+              : null,
+          waitlistedCount: entry.waitlistedCount ?? 0,
+          waitlistedPercent:
+            maxEnrollDenominator > 0
+              ? ((entry.waitlistedCount ?? 0) / maxEnrollDenominator) * 100
               : null,
           capacityCount: maxEnroll,
           capacityPercent:
@@ -489,16 +501,16 @@ export default function Enrollment() {
         <p className={styles.axisLabel}>Days since enrollment opened</p>
         {capacityTooltipElement}
       </div>
-      <div style={{ marginTop: 24 }}>
-        <WaitlistProbability
-          year={_class.year}
-          semester={_class.semester}
-          sessionId={_class.sessionId ?? null}
-          subject={_class.subject}
-          courseNumber={_class.courseNumber}
-          sectionNumber={_class.number}
-        />
-      </div>
+      <WaitlistProbability
+        year={_class.year}
+        semester={_class.semester}
+        sessionId={_class.sessionId ?? null}
+        subject={_class.subject}
+        courseNumber={_class.courseNumber}
+        sectionNumber={_class.number}
+        currentWaitlistedCount={currentWaitlistedCount}
+        courseLabel={`${_class.subject} ${_class.courseNumber} (Section ${_class.number})`}
+      />
     </ClassChartBox>
   );
 }

--- a/apps/frontend/src/lib/api/classes.ts
+++ b/apps/frontend/src/lib/api/classes.ts
@@ -406,6 +406,31 @@ export const GET_CLASS_GRADES = gql`
   }
 `;
 
+export const GET_CLASS_PRIMARY_SECTION_DATES = gql`
+  query GetClassPrimarySectionDates(
+    $year: Int!
+    $semester: Semester!
+    $sessionId: SessionIdentifier!
+    $subject: String!
+    $courseNumber: CourseNumber!
+    $number: ClassNumber!
+  ) {
+    class(
+      year: $year
+      semester: $semester
+      sessionId: $sessionId
+      subject: $subject
+      courseNumber: $courseNumber
+      number: $number
+    ) {
+      primarySection {
+        startDate
+        endDate
+      }
+    }
+  }
+`;
+
 export const GET_CLASS_ENROLLMENT = gql`
   query GetClassEnrollment(
     $year: Int!

--- a/apps/frontend/src/lib/api/waitlist.ts
+++ b/apps/frontend/src/lib/api/waitlist.ts
@@ -1,0 +1,18 @@
+import { gql } from "@apollo/client";
+
+export const GET_WAITLIST_PROBABILITY = gql`
+  query GetWaitlistProbability(
+    $k: Int!
+    $timeRemainingDays: Float!
+    $section: WaitlistSectionInput
+  ) {
+    waitlistGetInProbability(
+      k: $k
+      timeRemainingDays: $timeRemainingDays
+      section: $section
+    ) {
+      probability
+      lambdaUsed
+    }
+  }
+`;

--- a/package-lock.json
+++ b/package-lock.json
@@ -189,7 +189,6 @@
         "cheerio": "^1.0.0",
         "luxon": "^3.7.2",
         "papaparse": "^5.5.3",
-        "playwright": "*",
         "tslog": "^4.10.2"
       },
       "devDependencies": {

--- a/packages/gql-typedefs/index.ts
+++ b/packages/gql-typedefs/index.ts
@@ -20,3 +20,4 @@ export * from "./staff";
 export * from "./stats";
 export * from "./click-tracking";
 export * from "./targeted-message";
+export * from "./waitlist";

--- a/packages/gql-typedefs/waitlist.ts
+++ b/packages/gql-typedefs/waitlist.ts
@@ -1,0 +1,43 @@
+import { gql } from "graphql-tag";
+
+export const waitlistTypeDef = gql`
+  """
+  Estimate drop rate (lambda) from enrollment history.
+  """
+  input WaitlistSectionInput {
+    year: Int!
+    semester: Semester!
+    sessionId: SessionIdentifier
+    subject: String!
+    courseNumber: CourseNumber!
+    sectionNumber: SectionNumber!
+  }
+
+  """
+  Result of the Poisson waitlist "get in" probability calculation.
+  """
+  type WaitlistGetInProbability {
+    "Probability of getting in from the waitlist (0-1)."
+    probability: Float!
+    "Lambda (drops per day) used in the calculation."
+    lambdaUsed: Float
+  }
+
+  extend type Query {
+    """
+    Probability of getting in from waitlist position k before time T runs out,
+    assuming drops follow a Poisson process. Provide lambda (drops per day) and/or
+    section to estimate lambda from that section's enrollment history.
+    """
+    waitlistGetInProbability(
+      "Waitlist position (1 = first on waitlist)."
+      k: Int!
+      "Time remaining in days."
+      timeRemainingDays: Float!
+      "Average drop rate per day. If omitted, provide section to estimate from history or a default is used."
+      lambda: Float
+      "Section to estimate lambda from enrollment history (optional)."
+      section: WaitlistSectionInput
+    ): WaitlistGetInProbability!
+  }
+`;


### PR DESCRIPTION
experimental feature, please test out and give feedback on UI + the overall feature. thinking about maybe pivoting to a less intrusive UI where it can show each course's difficulty to get into (sort by calculated lambda)

uses poisson-based regression from past 3 semesters for data. 

future inclusions might include:
only showing the calculator if the semester is the current semester
only showing the calculator if it is during course enrollment season

also, it might be possible to create this feature with less files(?) or neater(?), so i can clean the code up if you find a better way to do so.