### PR TITLE
Update Vite configuration for staff and frontend to resolve react-is dependency 

### DIFF
--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -1,6 +1,14 @@
 import react from "@vitejs/plugin-react";
-import { resolve } from "path";
+import { createRequire } from "node:module";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vite";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
+// Recharts imports `react-is`; resolution can fail under esbuild when deps are hoisted
+// to the monorepo root (e.g. Docker + turbo prune). Resolve the real install path.
+const reactIsRoot = dirname(require.resolve("react-is/package.json"));
 
 export default defineConfig({
   server: {
@@ -11,7 +19,11 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": resolve(__dirname, "src"),
+      "react-is": reactIsRoot,
     },
+  },
+  optimizeDeps: {
+    include: ["react-is", "recharts"],
   },
   plugins: [
     react(),

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
     },
   },
   optimizeDeps: {
-    include: ["react-is", "recharts"],
+    include: ["react-is"],
   },
   plugins: [
     react(),

--- a/apps/staff-frontend/vite.config.ts
+++ b/apps/staff-frontend/vite.config.ts
@@ -1,6 +1,12 @@
 import react from "@vitejs/plugin-react";
-import { resolve } from "path";
+import { createRequire } from "node:module";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vite";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
+const reactIsRoot = dirname(require.resolve("react-is/package.json"));
 
 export default defineConfig({
   server: {
@@ -18,7 +24,11 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": resolve(__dirname, "src"),
+      "react-is": reactIsRoot,
     },
+  },
+  optimizeDeps: {
+    include: ["react-is", "recharts"],
   },
   plugins: [react()],
   css: {

--- a/apps/staff-frontend/vite.config.ts
+++ b/apps/staff-frontend/vite.config.ts
@@ -6,7 +6,14 @@ import { defineConfig } from "vite";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
-const reactIsRoot = dirname(require.resolve("react-is/package.json"));
+let reactIsRoot: string | null = null;
+try {
+  // In some Docker + turbo prune installs, `react-is` may not be hoisted to the
+  // app/root node_modules. Only alias it when we can resolve a concrete path.
+  reactIsRoot = dirname(require.resolve("react-is/package.json"));
+} catch {
+  reactIsRoot = null;
+}
 
 export default defineConfig({
   server: {
@@ -24,11 +31,11 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": resolve(__dirname, "src"),
-      "react-is": reactIsRoot,
+      ...(reactIsRoot ? { "react-is": reactIsRoot } : {}),
     },
   },
   optimizeDeps: {
-    include: ["react-is", "recharts"],
+    include: reactIsRoot ? ["react-is"] : [],
   },
   plugins: [react()],
   css: {


### PR DESCRIPTION
Resolved a local Docker turbo prune issue by prebundling react-is and recharts in Vite config.