### PR TITLE
Associated renamed courses correctly in grades

### DIFF
--- a/apps/backend/src/modules/class/resolver.ts
+++ b/apps/backend/src/modules/class/resolver.ts
@@ -252,7 +252,7 @@ const resolvers: ClassModule.Resolvers = {
         parent.semester,
         parent.sessionId,
         parent.subject,
-        parent.courseNumber,
+        parent.courseId,
         parent.number
       );
 

--- a/apps/backend/src/modules/course/resolver.ts
+++ b/apps/backend/src/modules/course/resolver.ts
@@ -123,13 +123,10 @@ const resolvers: CourseModule.Resolvers = {
           : undefined;
 
       // Cross-listed courses share a courseId, so filter to only classes
-      // matching this specific course's subject and number.
-      const matchesCourse = (courseClass: {
-        subject?: string | null;
-        courseNumber?: string | null;
-      }) =>
-        courseClass.subject === parent.subject &&
-        courseClass.courseNumber === parent.number;
+      // matching this specific course's subject. We don't filter by number
+      // to allow renamed courses (same subject, different number) to match.
+      const matchesCourse = (courseClass: { subject?: string | null }) =>
+        courseClass.subject === parent.subject;
 
       if (parent.classes) {
         let classes = [...parent.classes];
@@ -247,7 +244,7 @@ const resolvers: CourseModule.Resolvers = {
 
       const gradeDistribution = await getGradeDistributionByCourse(
         parent.subject,
-        parent.number
+        parent.courseId
       );
 
       return gradeDistribution;

--- a/apps/backend/src/modules/grade-distribution/controller.ts
+++ b/apps/backend/src/modules/grade-distribution/controller.ts
@@ -165,13 +165,13 @@ export const getGradeDistributionsByCourseIds = async (courseIds: string[]) => {
 
 export const getGradeDistributionByCourse = async (
   subject: string,
-  number: string
+  courseId: string
 ) => {
   const subjectQuery = buildSubjectQuery(subject);
 
   const sections = await SectionModel.find({
     subject: subjectQuery,
-    courseNumber: number,
+    courseId,
     primary: true,
   })
     .select({ sectionId: 1, termId: 1, sessionId: 1 })
@@ -185,7 +185,7 @@ export const getGradeDistributionByClass = async (
   semester: string,
   sessionId: string,
   subject: string,
-  courseNumber: string,
+  courseId: string,
   sectionNumber: string
 ) => {
   const subjectQuery = buildSubjectQuery(subject);
@@ -195,7 +195,7 @@ export const getGradeDistributionByClass = async (
     semester,
     sessionId,
     subject: subjectQuery,
-    courseNumber,
+    courseId,
     number: sectionNumber,
     primary: true,
   })
@@ -212,7 +212,7 @@ export const getGradeDistributionBySemester = async (
   semester: string,
   sessionId: string,
   subject: string,
-  courseNumber: string
+  courseId: string
 ) => {
   const subjectQuery = buildSubjectQuery(subject);
 
@@ -221,7 +221,7 @@ export const getGradeDistributionBySemester = async (
     semester,
     sessionId,
     subject: subjectQuery,
-    courseNumber,
+    courseId,
     primary: true,
   })
     .select({ sectionId: 1, termId: 1, sessionId: 1 })
@@ -232,7 +232,7 @@ export const getGradeDistributionBySemester = async (
 
 export const getGradeDistributionByInstructor = async (
   subject: string,
-  courseNumber: string,
+  courseId: string,
   familyName: string,
   givenName: string
 ) => {
@@ -240,7 +240,7 @@ export const getGradeDistributionByInstructor = async (
 
   const sections = await SectionModel.find({
     subject: subjectQuery,
-    courseNumber,
+    courseId,
     "meetings.instructors.familyName": familyName,
     "meetings.instructors.givenName": givenName,
     primary: true,
@@ -258,7 +258,7 @@ export const getGradeDistributionByInstructorAndSemester = async (
   semester: string,
   sessionId: string,
   subject: string,
-  courseNumber: string,
+  courseId: string,
   familyName: string,
   givenName: string
 ) => {
@@ -269,7 +269,7 @@ export const getGradeDistributionByInstructorAndSemester = async (
     semester,
     sessionId,
     subject: subjectQuery,
-    courseNumber,
+    courseId,
     "meetings.instructors.familyName": familyName,
     "meetings.instructors.givenName": givenName,
     primary: true,

--- a/apps/backend/src/modules/grade-distribution/resolver.ts
+++ b/apps/backend/src/modules/grade-distribution/resolver.ts
@@ -16,7 +16,7 @@ const resolvers: GradeDistributionModule.Resolvers = {
         semester,
         sessionId,
         subject,
-        courseNumber,
+        courseId,
         classNumber,
         familyName,
         givenName,
@@ -31,7 +31,7 @@ const resolvers: GradeDistributionModule.Resolvers = {
           semester,
           sessionId,
           subject,
-          courseNumber,
+          courseId,
           familyName,
           givenName
         );
@@ -43,7 +43,7 @@ const resolvers: GradeDistributionModule.Resolvers = {
           semester,
           sessionId,
           subject,
-          courseNumber,
+          courseId,
           classNumber
         );
       }
@@ -51,7 +51,7 @@ const resolvers: GradeDistributionModule.Resolvers = {
       if (givenName && familyName) {
         return await getGradeDistributionByInstructor(
           subject,
-          courseNumber,
+          courseId,
           familyName,
           givenName
         );
@@ -63,11 +63,11 @@ const resolvers: GradeDistributionModule.Resolvers = {
           semester,
           sessionId,
           subject,
-          courseNumber
+          courseId
         );
       }
 
-      return await getGradeDistributionByCourse(subject, courseNumber);
+      return await getGradeDistributionByCourse(subject, courseId);
     },
   },
 };

--- a/apps/frontend/src/app/Grades/index.tsx
+++ b/apps/frontend/src/app/Grades/index.tsx
@@ -388,6 +388,7 @@ function FilterPanel({
     if (!hasInstructor && !hasSemester) {
       return {
         subject: selectedCourse.subject,
+        courseId: selectedCourse.courseId,
         courseNumber: selectedCourse.number,
       };
     }
@@ -398,6 +399,7 @@ function FilterPanel({
       if (selectedType === InputType.Term) {
         return {
           subject: selectedCourse.subject,
+          courseId: selectedCourse.courseId,
           courseNumber: selectedCourse.number,
           type: InputType.Term,
           year: parsedTerm.year,
@@ -409,6 +411,7 @@ function FilterPanel({
       }
       return {
         subject: selectedCourse.subject,
+        courseId: selectedCourse.courseId,
         courseNumber: selectedCourse.number,
         type: InputType.Instructor,
         familyName,
@@ -423,6 +426,7 @@ function FilterPanel({
     if (hasSemester) {
       return {
         subject: selectedCourse.subject,
+        courseId: selectedCourse.courseId,
         courseNumber: selectedCourse.number,
         type: InputType.Term,
         year: parsedTerm.year,
@@ -435,6 +439,7 @@ function FilterPanel({
     const [familyName, givenName] = instructor.split(", ");
     return {
       subject: selectedCourse.subject,
+      courseId: selectedCourse.courseId,
       courseNumber: selectedCourse.number,
       type: InputType.Instructor,
       familyName,
@@ -936,7 +941,7 @@ export default function Grades() {
         setEditDraft({
           subject: input.subject,
           courseNumber: input.courseNumber,
-          courseId: `${input.subject}-${input.courseNumber}`,
+          courseId: input.courseId,
           type: input.type,
           givenName: "givenName" in input ? input.givenName : undefined,
           familyName: "familyName" in input ? input.familyName : undefined,

--- a/apps/frontend/src/components/CourseAnalytics/types.ts
+++ b/apps/frontend/src/components/CourseAnalytics/types.ts
@@ -7,7 +7,8 @@ export enum InputType {
 
 interface BaseInput {
   subject: string;
-  courseNumber: string;
+  courseId: string;
+  courseNumber: string; // For display purposes only
   type?: InputType;
 }
 
@@ -86,38 +87,38 @@ export const MAX_COURSES = 6;
 
 export const getInputSearchParam = (input: Input) => {
   // Course input
-  if (!input.type) return `${input.subject};${input.courseNumber}`;
+  if (!input.type) return `${input.subject};${input.courseId}`;
 
   // Term input
   if (input.type === InputType.Term) {
     const termSegment = `${input.year}:${input.semester}:${input.sessionId}`;
     if (!input.givenName && !input.familyName) {
-      return `${input.subject};${input.courseNumber};T;${termSegment}`;
+      return `${input.subject};${input.courseId};T;${termSegment}`;
     }
 
-    return `${input.subject};${input.courseNumber};T;${termSegment};${input.givenName}:${input.familyName}`;
+    return `${input.subject};${input.courseId};T;${termSegment};${input.givenName}:${input.familyName}`;
   }
 
   // Instructor input
   if (!input.year && !input.semester) {
-    return `${input.subject};${input.courseNumber};P;${input.givenName}:${input.familyName}`;
+    return `${input.subject};${input.courseId};P;${input.givenName}:${input.familyName}`;
   }
 
   const termSegment = `${input.year}:${input.semester}:${input.sessionId}`;
 
-  return `${input.subject};${input.courseNumber};P;${input.givenName}:${input.familyName};${termSegment}`;
+  return `${input.subject};${input.courseId};P;${input.givenName}:${input.familyName};${termSegment}`;
 };
 
 export const isInputEqual = (a: Input, b: Input) => {
   if (!a.type && !b.type)
-    return b.courseNumber === a.courseNumber && b.subject === a.subject;
+    return b.courseId === a.courseId && b.subject === a.subject;
 
   if (a.type !== b.type) return false;
 
   if (a.type === InputType.Term && b.type === InputType.Term) {
     return (
       b.subject === a.subject &&
-      b.courseNumber === a.courseNumber &&
+      b.courseId === a.courseId &&
       b.givenName === a.givenName &&
       b.familyName === a.familyName &&
       b.year === a.year &&
@@ -129,7 +130,7 @@ export const isInputEqual = (a: Input, b: Input) => {
   if (a.type === InputType.Instructor && b.type === InputType.Instructor) {
     const baseMatch =
       b.subject === a.subject &&
-      b.courseNumber === a.courseNumber &&
+      b.courseId === a.courseId &&
       b.givenName === a.givenName &&
       b.familyName === a.familyName;
     if (a.year && a.semester && b.year && b.semester) {

--- a/apps/frontend/src/lib/api/grade-distributions.ts
+++ b/apps/frontend/src/lib/api/grade-distributions.ts
@@ -14,7 +14,7 @@ export const READ_GRADE_DISTRIBUTION = gql`
     $semester: Semester
     $sessionId: SessionIdentifier
     $subject: String!
-    $courseNumber: CourseNumber!
+    $courseId: String!
     $classNumber: ClassNumber
     $familyName: String
     $givenName: String
@@ -24,7 +24,7 @@ export const READ_GRADE_DISTRIBUTION = gql`
       semester: $semester
       sessionId: $sessionId
       subject: $subject
-      courseNumber: $courseNumber
+      courseId: $courseId
       classNumber: $classNumber
       familyName: $familyName
       givenName: $givenName

--- a/apps/frontend/src/utils/url-course-parser.ts
+++ b/apps/frontend/src/utils/url-course-parser.ts
@@ -60,23 +60,27 @@ function parseInstructor(
  * Parses a single input string from URL parameters
  *
  * Format examples:
- * - Basic: "COMPSCI;61B"
- * - Term: "COMPSCI;61B;T;2024:Spring:001"
- * - Instructor: "COMPSCI;61B;P;John:DeNero"
- * - Full: "COMPSCI;61B;T;2024:Spring:001;John:DeNero"
+ * - Basic: "COMPSCI;courseId123" (subject;courseId)
+ * - Term: "COMPSCI;courseId123;T;2024:Spring:001"
+ * - Instructor: "COMPSCI;courseId123;P;John:DeNero"
+ * - Full: "COMPSCI;courseId123;T;2024:Spring:001;John:DeNero"
+ *
+ * Note: courseId is used instead of courseNumber to support renamed courses.
+ * courseNumber is derived from the course lookup.
  */
 function parseInputString(inputString: string): Input | null {
   const parts = inputString.split(";");
 
-  // Minimum required: subject and course number
+  // Minimum required: subject and courseId
   if (parts.length < 2) return null;
 
-  const [subject, courseNumber] = parts;
-  if (!subject || !courseNumber) return null;
+  const [subject, courseId] = parts;
+  if (!subject || !courseId) return null;
 
-  // Basic format: just subject and course number
+  // Basic format: just subject and courseId
+  // courseNumber is set to empty string - will be resolved by the component
   if (parts.length < 4) {
-    return { subject, courseNumber };
+    return { subject, courseId, courseNumber: "" };
   }
 
   const typeToken = parts[2];
@@ -97,7 +101,8 @@ function parseInputString(inputString: string): Input | null {
 
     const baseInput: Input = {
       subject,
-      courseNumber,
+      courseId,
+      courseNumber: "",
       type: InputType.Term,
       ...term,
     };
@@ -115,7 +120,8 @@ function parseInputString(inputString: string): Input | null {
 
     const baseInput: Input = {
       subject,
-      courseNumber,
+      courseId,
+      courseNumber: "",
       type: InputType.Instructor,
       ...instructor,
     };

--- a/packages/gql-typedefs/grade-distribution.ts
+++ b/packages/gql-typedefs/grade-distribution.ts
@@ -19,7 +19,7 @@ export const gradeDistributionTypeDef = gql`
       semester: Semester
       sessionId: SessionIdentifier
       subject: String!
-      courseNumber: CourseNumber!
+      courseId: String!
       classNumber: ClassNumber
       familyName: String
       givenName: String


### PR DESCRIPTION
Added grades to search by course Id and subject instead of subject and number. This is to protect against changes of course names, while still filtering out cross-listed courses.