### PR TITLE
henry/fixed z-index for color dropdown

### DIFF
--- a/apps/frontend/src/components/ColorSelector/ColorSelector.module.scss
+++ b/apps/frontend/src/components/ColorSelector/ColorSelector.module.scss
@@ -31,7 +31,7 @@
 }
 
 .colorDropdown {
-  z-index: var(--z-popover);
+  z-index: 9999; /* Must escape Radix Dialog's internal layers; --z-popover (500) is insufficient */
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
   scroll-behavior: smooth;


### PR DESCRIPTION
radix dialog has their own layers, changed z-index to 9999 to make sure it renders aboves that