### PR TITLE
Set Redis eviction policy to volatile-lru

### DIFF
--- a/infra/redis/values.yaml
+++ b/infra/redis/values.yaml
@@ -10,3 +10,5 @@ redis:
   master:
     persistence:
       enabled: false
+    configuration: |
+      maxmemory-policy volatile-lru


### PR DESCRIPTION
## Summary

- Adds `maxmemory-policy volatile-lru` to the production Redis Helm chart config
- Without this, open-source Redis defaults to `noeviction` — writes fail with OOM errors once memory is full rather than evicting keys
- `volatile-lru` evicts least recently used keys that have a TTL set, which covers `apollo-cache:*`, `user-session:*`, `rate-limit:*`, and `view-dedupe:*` keys
- Keys without TTLs (`view-counter:*`, `semantic_search:*`) are intentionally preserved — they rely on application-level cleanup

## Why volatile-lru and not allkeys-lru

`allkeys-lru` would evict any key including sessions and view counters indiscriminately. `volatile-lru` only evicts TTL-bearing keys, so persistent counters and vector search indexes are safe from eviction pressure.

## Test plan

- [ ] Deploy to staging and verify `redis-cli CONFIG GET maxmemory-policy` returns `volatile-lru`
- [ ] Confirm sessions, apollo cache, and rate limiting continue to function normally after deploy

https://claude.ai/code/session_01FtmG7GXteM4x9tJLr9naHG