### PR TITLE
feat: add "no conflict with schedule" filter to catalog

### DIFF
--- a/apps/frontend/src/components/ClassBrowser/Filters/ScheduleConflictFilter.tsx
+++ b/apps/frontend/src/components/ClassBrowser/Filters/ScheduleConflictFilter.tsx
@@ -1,0 +1,59 @@
+import { useMemo } from "react";
+
+import { Select } from "@repo/theme";
+
+import { useReadSchedules } from "@/hooks/api";
+import useUser from "@/hooks/useUser";
+
+import { useFilterContext } from "../context/FilterContext";
+import styles from "./Filters.module.scss";
+
+export default function ScheduleConflictFilter() {
+  const { user } = useUser();
+  const {
+    year,
+    semester,
+    scheduleConflictFilter,
+    updateScheduleConflictFilter,
+  } = useFilterContext();
+
+  // Only fetch schedules if user is logged in
+  const { data: schedules, loading } = useReadSchedules({
+    skip: !user,
+  });
+
+  // Filter schedules to current term
+  const matchingSchedules = useMemo(() => {
+    if (!schedules) return [];
+    return schedules.filter(
+      (s) => s?.year === year && s?.semester === semester
+    );
+  }, [schedules, year, semester]);
+
+  // Don't render if not logged in
+  if (!user) return null;
+
+  // Don't render if no schedules for this term (but still show if loading)
+  if (!loading && matchingSchedules.length === 0) return null;
+
+  const options = matchingSchedules.map((s) => ({
+    value: s!._id,
+    label: s!.name,
+  }));
+
+  return (
+    <div className={styles.formControl}>
+      <p className={styles.label}>No Conflict With Schedule</p>
+      <Select
+        value={scheduleConflictFilter}
+        placeholder="Select a schedule"
+        clearable
+        disabled={loading}
+        onChange={(value) =>
+          updateScheduleConflictFilter(Array.isArray(value) ? value[0] : value)
+        }
+        options={options}
+      />
+    </div>
+  );
+}

--- a/apps/frontend/src/components/ClassBrowser/Filters/index.tsx
+++ b/apps/frontend/src/components/ClassBrowser/Filters/index.tsx
@@ -26,6 +26,7 @@ import {
 import { useFilterContext } from "../context/FilterContext";
 import { useLayoutContext } from "../context/LayoutContext";
 import styles from "./Filters.module.scss";
+import ScheduleConflictFilter from "./ScheduleConflictFilter";
 
 type RequirementSelection =
   | { type: "breadth"; value: string }
@@ -64,6 +65,7 @@ export default function Filters() {
     semester,
     terms,
     filterOptions,
+    updateScheduleConflictFilter,
   } = useFilterContext();
 
   const navigate = useNavigate();
@@ -216,6 +218,7 @@ export default function Filters() {
     updateTimeRange([null, null]);
     updateSortBy(SortBy.Relevance);
     updateEnrollmentFilter(null);
+    updateScheduleConflictFilter(null);
   };
 
   return (
@@ -368,6 +371,7 @@ export default function Filters() {
             }))}
           />
         </div>
+        <ScheduleConflictFilter />
         <div className={styles.formControl}>
           <p className={styles.label}>Grading Option</p>
           <Select<GradingFilter>

--- a/apps/frontend/src/components/ClassBrowser/context/FilterContext.ts
+++ b/apps/frontend/src/components/ClassBrowser/context/FilterContext.ts
@@ -31,6 +31,7 @@ export interface FilterContextType {
   enrollmentFilter: EnrollmentFilter | null;
   online: boolean;
   filterOptions: ICatalogFilterOptions | null;
+  scheduleConflictFilter: string | null;
   updateUnits: Dispatch<UnitRange>;
   updateLevels: Dispatch<Level[]>;
   updateDays: Dispatch<Day[]>;
@@ -42,6 +43,7 @@ export interface FilterContextType {
   updateEnrollmentFilter: Dispatch<EnrollmentFilter | null>;
   updateOnline: Dispatch<boolean>;
   updateReverse: Dispatch<SetStateAction<boolean>>;
+  updateScheduleConflictFilter: Dispatch<string | null>;
 }
 
 export const FilterContext = createContext<FilterContextType | null>(null);

--- a/apps/frontend/src/components/ClassBrowser/hooks/useCatalogBrowser.ts
+++ b/apps/frontend/src/components/ClassBrowser/hooks/useCatalogBrowser.ts
@@ -1,7 +1,10 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 
+import { useReadSchedules } from "@/hooks/api";
+import useUser from "@/hooks/useUser";
 import { ITerm } from "@/lib/api";
 import { Semester } from "@/lib/generated/graphql";
+import { classConflictsWithSchedule } from "@/lib/schedule/conflict";
 
 import { FilterContextType } from "../context/FilterContext";
 import { ListContextType } from "../context/ListContext";
@@ -84,6 +87,37 @@ export default function useCatalogBrowser({
     semanticSearch: isSemanticMode,
   });
 
+  // Schedule conflict filtering
+  const { user } = useUser();
+  const { data: schedules } = useReadSchedules({
+    skip: !user || !filterState.scheduleConflictFilter,
+  });
+
+  // Find the selected schedule
+  const selectedSchedule = useMemo(() => {
+    if (!filterState.scheduleConflictFilter || !schedules) return null;
+    return (
+      schedules.find((s) => s?._id === filterState.scheduleConflictFilter) ??
+      null
+    );
+  }, [filterState.scheduleConflictFilter, schedules]);
+
+  // Filter classes based on schedule conflicts
+  const filteredClasses = useMemo(() => {
+    if (!selectedSchedule) return queryResult.classes;
+
+    return queryResult.classes.filter((catalogClass) => {
+      // Get class meetings from the catalog class
+      const meetings = catalogClass.meetings ?? [];
+
+      // Classes without meetings don't conflict
+      if (meetings.length === 0) return true;
+
+      // Keep classes that DON'T conflict with the schedule
+      return !classConflictsWithSchedule(meetings, selectedSchedule);
+    });
+  }, [queryResult.classes, selectedSchedule]);
+
   const filterContextValue: FilterContextType = useMemo(
     () => ({
       year,
@@ -102,6 +136,7 @@ export default function useCatalogBrowser({
       enrollmentFilter: filterState.enrollmentFilter,
       online: filterState.online,
       filterOptions: queryResult.filterOptions,
+      scheduleConflictFilter: filterState.scheduleConflictFilter,
       updateUnits: filterState.updateUnits,
       updateLevels: filterState.updateLevels,
       updateDays: filterState.updateDays,
@@ -113,22 +148,25 @@ export default function useCatalogBrowser({
       updateEnrollmentFilter: filterState.updateEnrollmentFilter,
       updateOnline: filterState.updateOnline,
       updateReverse: filterState.updateReverse,
+      updateScheduleConflictFilter: filterState.updateScheduleConflictFilter,
     }),
     [year, semester, terms, filterState, queryResult.filterOptions]
   );
 
   const listContextValue: ListContextType = useMemo(
     () => ({
-      classes: queryResult.classes,
+      classes: filteredClasses,
       loading: queryResult.loading,
-      totalCount: queryResult.totalCount,
+      totalCount: selectedSchedule
+        ? filteredClasses.length
+        : queryResult.totalCount,
       page: queryResult.page,
       pageSize: queryResult.pageSize,
-      hasNextPage: queryResult.hasNextPage,
+      hasNextPage: selectedSchedule ? false : queryResult.hasNextPage,
       loadNextPage: queryResult.loadNextPage,
       isLoadingNextPage: queryResult.isLoadingNextPage,
     }),
-    [queryResult]
+    [queryResult, filteredClasses, selectedSchedule]
   );
 
   return {

--- a/apps/frontend/src/components/ClassBrowser/hooks/useCatalogBrowser.ts
+++ b/apps/frontend/src/components/ClassBrowser/hooks/useCatalogBrowser.ts
@@ -93,14 +93,18 @@ export default function useCatalogBrowser({
     skip: !user || !filterState.scheduleConflictFilter,
   });
 
-  // Find the selected schedule
+  // Find the selected schedule - must match current term to be active
   const selectedSchedule = useMemo(() => {
     if (!filterState.scheduleConflictFilter || !schedules) return null;
-    return (
-      schedules.find((s) => s?._id === filterState.scheduleConflictFilter) ??
-      null
+    const schedule = schedules.find(
+      (s) => s?._id === filterState.scheduleConflictFilter
     );
-  }, [filterState.scheduleConflictFilter, schedules]);
+    // Only use the schedule if it matches the current term
+    if (!schedule || schedule.year !== year || schedule.semester !== semester) {
+      return null;
+    }
+    return schedule;
+  }, [filterState.scheduleConflictFilter, schedules, year, semester]);
 
   // Filter classes based on schedule conflicts
   const filteredClasses = useMemo(() => {
@@ -157,12 +161,14 @@ export default function useCatalogBrowser({
     () => ({
       classes: filteredClasses,
       loading: queryResult.loading,
+      // When schedule filter is active, show filtered count but keep pagination working
+      // so all pages can be loaded and filtered
       totalCount: selectedSchedule
         ? filteredClasses.length
         : queryResult.totalCount,
       page: queryResult.page,
       pageSize: queryResult.pageSize,
-      hasNextPage: selectedSchedule ? false : queryResult.hasNextPage,
+      hasNextPage: queryResult.hasNextPage,
       loadNextPage: queryResult.loadNextPage,
       isLoadingNextPage: queryResult.isLoadingNextPage,
     }),

--- a/apps/frontend/src/components/ClassBrowser/hooks/useCatalogFilters.ts
+++ b/apps/frontend/src/components/ClassBrowser/hooks/useCatalogFilters.ts
@@ -117,6 +117,7 @@ export interface CatalogFilterState {
   effectiveOrder: "asc" | "desc";
   enrollmentFilter: EnrollmentFilter | null;
   online: boolean;
+  scheduleConflictFilter: string | null;
   hasActiveFilters: boolean;
   filterVariables: ICatalogFilters | undefined;
 }
@@ -134,6 +135,7 @@ export interface CatalogFilterUpdaters {
   updateEnrollmentFilter: Dispatch<EnrollmentFilter | null>;
   updateOnline: Dispatch<boolean>;
   updateReverse: Dispatch<SetStateAction<boolean>>;
+  updateScheduleConflictFilter: Dispatch<string | null>;
 }
 
 export type UseCatalogFiltersReturn = CatalogFilterState &
@@ -162,6 +164,8 @@ export default function useCatalogFilters({
   const [localEnrollmentFilter, setLocalEnrollmentFilter] =
     useState<EnrollmentFilter | null>(null);
   const [localOnline, setLocalOnline] = useState<boolean>(false);
+  const [localScheduleConflictFilter, setLocalScheduleConflictFilter] =
+    useState<string | null>(null);
 
   // Derive state from search params when persistent
   const query = localQuery;
@@ -335,7 +339,8 @@ export default function useCatalogFilters({
     gradingFilters.length > 0 ||
     enrollmentFilter !== null ||
     online ||
-    sortBy !== SortBy.Relevance;
+    sortBy !== SortBy.Relevance ||
+    localScheduleConflictFilter !== null;
 
   // URL sync updater helpers
   const updateArray = <T>(
@@ -460,5 +465,7 @@ export default function useCatalogFilters({
     },
     updateOnline: (o) => updateBoolean("online", setLocalOnline, o),
     updateReverse: setLocalReverse,
+    scheduleConflictFilter: localScheduleConflictFilter,
+    updateScheduleConflictFilter: setLocalScheduleConflictFilter,
   };
 }

--- a/apps/frontend/src/lib/api/catalog.ts
+++ b/apps/frontend/src/lib/api/catalog.ts
@@ -56,6 +56,11 @@ export const GET_CATALOG_SEARCH = gql`
         decal {
           title
         }
+        meetings {
+          days
+          startTime
+          endTime
+        }
       }
       totalCount
     }

--- a/apps/frontend/src/lib/schedule/conflict.ts
+++ b/apps/frontend/src/lib/schedule/conflict.ts
@@ -1,0 +1,123 @@
+import type { IScheduleListSchedule } from "@/lib/api/schedules";
+
+/**
+ * Meeting time interface for conflict detection.
+ * Compatible with both catalog classes and schedule sections/events.
+ */
+export interface Meeting {
+  days?: (boolean | null)[] | null;
+  startTime?: string | null;
+  endTime?: string | null;
+}
+
+/**
+ * Parse time string "HH:MM" to minutes since midnight.
+ */
+export const parseTime = (time: string): number => {
+  const [hours, minutes] = time.split(":").map(Number);
+  return hours * 60 + minutes;
+};
+
+/**
+ * Check if two meetings overlap in time.
+ * Returns true if meetings occur on the same day and their times overlap.
+ */
+export const meetingsOverlap = (
+  meeting1: Meeting,
+  meeting2: Meeting
+): boolean => {
+  // Check if meetings occur on the same day
+  const sameDay = meeting1.days?.some(
+    (day, index) => day && meeting2.days?.[index]
+  );
+  if (!sameDay) return false;
+
+  // Both meetings must have valid times
+  if (
+    !meeting1.startTime ||
+    !meeting1.endTime ||
+    !meeting2.startTime ||
+    !meeting2.endTime
+  ) {
+    return false;
+  }
+
+  const start1 = parseTime(meeting1.startTime);
+  const end1 = parseTime(meeting1.endTime);
+  const start2 = parseTime(meeting2.startTime);
+  const end2 = parseTime(meeting2.endTime);
+
+  // Two time ranges overlap if: start1 < end2 AND start2 < end1
+  // This covers all overlap cases: partial overlap, one containing the other, etc.
+  return start1 < end2 && start2 < end1;
+};
+
+/**
+ * Get all meetings from a schedule that should be checked for conflicts.
+ * This includes:
+ * - Meetings from selected sections of non-hidden classes
+ * - Custom events that are not hidden
+ */
+export const getScheduleMeetings = (
+  schedule: NonNullable<IScheduleListSchedule>
+): Meeting[] => {
+  const meetings: Meeting[] = [];
+
+  // Get meetings from non-hidden classes
+  for (const scheduleClass of schedule.classes) {
+    if (scheduleClass.hidden) continue;
+
+    const classData = scheduleClass.class;
+    const allSections = [classData.primarySection, ...classData.sections];
+
+    // Get meetings from selected sections only
+    for (const selectedSection of scheduleClass.selectedSections) {
+      const section = allSections.find(
+        (s) => s?.sectionId === selectedSection.sectionId
+      );
+      if (section?.meetings) {
+        meetings.push(...section.meetings);
+      }
+    }
+  }
+
+  // Get non-hidden custom events
+  for (const event of schedule.events) {
+    if (event.hidden) continue;
+    meetings.push({
+      days: event.days,
+      startTime: event.startTime,
+      endTime: event.endTime,
+    });
+  }
+
+  return meetings;
+};
+
+/**
+ * Check if a class's meetings conflict with any meetings in a schedule.
+ * Returns true if there is at least one conflict.
+ *
+ * @param classMeetings - The meetings from the catalog class to check
+ * @param schedule - The schedule to check against (non-hidden items only)
+ */
+export const classConflictsWithSchedule = (
+  classMeetings: Meeting[],
+  schedule: NonNullable<IScheduleListSchedule>
+): boolean => {
+  if (classMeetings.length === 0) return false;
+
+  const scheduleMeetings = getScheduleMeetings(schedule);
+  if (scheduleMeetings.length === 0) return false;
+
+  // Check if any class meeting conflicts with any schedule meeting
+  for (const classMeeting of classMeetings) {
+    for (const scheduleMeeting of scheduleMeetings) {
+      if (meetingsOverlap(classMeeting, scheduleMeeting)) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+};


### PR DESCRIPTION
Adds a new filter option that allows users to select one of their schedules and filter out catalog classes that conflict with non-hidden items in that schedule.

- Extract conflict detection utilities to lib/schedule/conflict.ts
- Add ScheduleConflictFilter component (only shown when logged in)
- Add meetings field to catalog search query for conflict detection
- Filter classes client-side based on schedule conflicts