### PR TITLE
Add backend runtime metrics + bound heap/probes

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -44,6 +44,7 @@
     "@opentelemetry/sdk-logs": "^0.56.0",
     "@opentelemetry/sdk-metrics": "^1.29.0",
     "@opentelemetry/sdk-node": "^0.56.0",
+    "@opentelemetry/instrumentation-runtime-node": "^0.13.0",
     "@apollo/server-plugin-response-cache": "^5.0.0",
     "@apollo/utils.keyvadapter": "^4.0.1",
     "@as-integrations/express5": "^1.1.2",

--- a/apps/backend/src/instrumentation.ts
+++ b/apps/backend/src/instrumentation.ts
@@ -13,16 +13,15 @@
  * and the OTel API returns no-ops, so there is no runtime overhead beyond
  * the initial module load.
  */
-
-import { NodeSDK } from "@opentelemetry/sdk-node";
 import { getNodeAutoInstrumentations } from "@opentelemetry/auto-instrumentations-node";
-import { RuntimeNodeInstrumentation } from "@opentelemetry/instrumentation-runtime-node";
-import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
-import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-http";
 import { OTLPLogExporter } from "@opentelemetry/exporter-logs-otlp-http";
-import { PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";
-import { BatchLogRecordProcessor } from "@opentelemetry/sdk-logs";
+import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-http";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
+import { RuntimeNodeInstrumentation } from "@opentelemetry/instrumentation-runtime-node";
 import { Resource } from "@opentelemetry/resources";
+import { BatchLogRecordProcessor } from "@opentelemetry/sdk-logs";
+import { PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";
+import { NodeSDK } from "@opentelemetry/sdk-node";
 
 const endpoint = process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
 
@@ -30,8 +29,7 @@ if (endpoint) {
   const resource = new Resource({
     "service.name": process.env.OTEL_SERVICE_NAME || "backend",
     "service.version": process.env.SERVICE_VERSION || "0.1.0",
-    "deployment.environment":
-      process.env.DEPLOYMENT_ENVIRONMENT || "local",
+    "deployment.environment": process.env.DEPLOYMENT_ENVIRONMENT || "local",
   });
 
   const sdk = new NodeSDK({

--- a/apps/backend/src/instrumentation.ts
+++ b/apps/backend/src/instrumentation.ts
@@ -16,6 +16,7 @@
 
 import { NodeSDK } from "@opentelemetry/sdk-node";
 import { getNodeAutoInstrumentations } from "@opentelemetry/auto-instrumentations-node";
+import { RuntimeNodeInstrumentation } from "@opentelemetry/instrumentation-runtime-node";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
 import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-http";
 import { OTLPLogExporter } from "@opentelemetry/exporter-logs-otlp-http";
@@ -68,6 +69,14 @@ if (endpoint) {
         "@opentelemetry/instrumentation-fs": { enabled: false },
         "@opentelemetry/instrumentation-dns": { enabled: false },
         "@opentelemetry/instrumentation-net": { enabled: false },
+      }),
+      // Node.js runtime metrics: event-loop delay/utilization, GC duration,
+      // and V8 heap usage. These are the signals needed to diagnose periodic
+      // event-loop stalls (GC pauses / heap pressure) that make /healthz time
+      // out even though the backend process stays up.
+      new RuntimeNodeInstrumentation({
+        // Sample the event loop frequently enough to catch multi-second stalls.
+        monitoringPrecision: 5000,
       }),
     ],
   });

--- a/apps/backend/src/lib/metrics.ts
+++ b/apps/backend/src/lib/metrics.ts
@@ -4,7 +4,6 @@
  * When OTel is not initialized, the metrics API returns no-op instruments,
  * so all counters/histograms are always safe to use.
  */
-
 import { metrics } from "@opentelemetry/api";
 import { monitorEventLoopDelay } from "perf_hooks";
 

--- a/apps/backend/src/lib/metrics.ts
+++ b/apps/backend/src/lib/metrics.ts
@@ -6,6 +6,7 @@
  */
 
 import { metrics } from "@opentelemetry/api";
+import { monitorEventLoopDelay } from "perf_hooks";
 
 const meter = metrics.getMeter("berkeleytime-backend");
 
@@ -55,3 +56,63 @@ export const redisCacheOpDuration = meter.createHistogram(
     unit: "ms",
   }
 );
+
+// ── Process health (event-loop lag + memory) ───────────────────────────
+//
+// Self-contained runtime signals using only Node built-ins, so they report
+// even before @opentelemetry/instrumentation-runtime-node is installed.
+// A periodic spike in event-loop lag that lines up with /healthz readiness
+// failures confirms the loop is being blocked (GC pause or synchronous CPU
+// work) rather than a slow Mongo/Redis dependency.
+
+// Histogram of event-loop delay sampled every 20ms; read + reset each export.
+const eventLoopDelay = monitorEventLoopDelay({ resolution: 20 });
+eventLoopDelay.enable();
+
+const NS_PER_MS = 1e6;
+
+const eventLoopLagMax = meter.createObservableGauge(
+  "process.eventloop.lag.max",
+  {
+    description: "Max event-loop delay since last collection",
+    unit: "ms",
+  }
+);
+
+const eventLoopLagP99 = meter.createObservableGauge(
+  "process.eventloop.lag.p99",
+  {
+    description: "p99 event-loop delay since last collection",
+    unit: "ms",
+  }
+);
+
+// Single batched callback so both gauges read the same snapshot before reset
+// (per-instrument callback order is not guaranteed).
+meter.addBatchObservableCallback(
+  (result) => {
+    result.observe(eventLoopLagMax, eventLoopDelay.max / NS_PER_MS);
+    result.observe(eventLoopLagP99, eventLoopDelay.percentile(99) / NS_PER_MS);
+    // Reset so each export window reflects only that interval.
+    eventLoopDelay.reset();
+  },
+  [eventLoopLagMax, eventLoopLagP99]
+);
+
+meter
+  .createObservableGauge("process.memory.heap_used", {
+    description: "V8 heap used",
+    unit: "By",
+  })
+  .addCallback((result) => {
+    result.observe(process.memoryUsage().heapUsed);
+  });
+
+meter
+  .createObservableGauge("process.memory.rss", {
+    description: "Resident set size",
+    unit: "By",
+  })
+  .addCallback((result) => {
+    result.observe(process.memoryUsage().rss);
+  });

--- a/infra/app/templates/backend.yaml
+++ b/infra/app/templates/backend.yaml
@@ -26,10 +26,25 @@ spec:
                 name: {{ include "bt-app.backendName" . }}-env
             - secretRef:
                 name: {{ include "bt-app.backendName" . }}-secret
+          env:
+            # Cap the V8 old-space heap below the container memory limit so GC
+            # runs proactively at a predictable bound instead of letting the
+            # heap grow toward node RAM and thrash in back-to-back full GCs.
+            # Leaves headroom for non-heap memory (buffers, zlib, native).
+            - name: NODE_OPTIONS
+              value: "--max-old-space-size=1024"
           resources:
             requests:
+              # Give the latency-sensitive Node process a CPU floor so it is not
+              # the lowest-priority workload on the node during contention.
+              cpu: "500m"
+              memory: "768Mi"
               ephemeral-storage: "500Mi"
             limits:
+              # No CPU limit on purpose: CFS throttling would stall the single
+              # event-loop thread and cause exactly the /healthz timeouts we're
+              # fixing. Memory is bounded so a true leak gets recycled.
+              memory: "1536Mi"
               ephemeral-storage: "2Gi"
           readinessProbe:
             httpGet:
@@ -39,6 +54,18 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 3
             failureThreshold: 3
+          # Liveness is intentionally far more lenient than readiness: a few
+          # seconds of event-loop lag should pull the pod from the Service
+          # (readiness) but NOT restart it. Only a genuine multi-minute wedge
+          # (~150s unresponsive) triggers a restart as a last resort.
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.backend.port }}
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 10
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -109,6 +109,7 @@
         "@opentelemetry/exporter-logs-otlp-http": "^0.56.0",
         "@opentelemetry/exporter-metrics-otlp-http": "^0.56.0",
         "@opentelemetry/exporter-trace-otlp-http": "^0.56.0",
+        "@opentelemetry/instrumentation-runtime-node": "^0.13.0",
         "@opentelemetry/resources": "^1.29.0",
         "@opentelemetry/sdk-logs": "^0.56.0",
         "@opentelemetry/sdk-metrics": "1.29.0",
@@ -7010,6 +7011,52 @@
       },
       "engines": {
         "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-runtime-node": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-runtime-node/-/instrumentation-runtime-node-0.13.0.tgz",
+      "integrity": "sha512-+uJN4KVRx5t26s/pchP6wN8Y2bFbuVsPPDjUklXfEGtfGJkwUZmBKafhw3c74ihwEo8RSSy2xqRhLSwp7zIYOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.200.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-runtime-node/node_modules/@opentelemetry/api-logs": {
+      "version": "0.200.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.200.0.tgz",
+      "integrity": "sha512-IKJBQxh91qJ+3ssRly5hYEJ8NDHu9oY/B1PXVSCWf7zytmYO9RNLB0Ox9XQ/fJ8m6gY6Q6NtBWlmXfaXt5Uc4Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-runtime-node/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.200.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.200.0.tgz",
+      "integrity": "sha512-pmPlzfJd+vvgaZd/reMsC8RWgTXn2WY1OWT5RT42m3aOn5532TozwXNDhg1vzqJ+jnvmkREcdLr27ebJEQt0Jg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.200.0",
+        "@types/shimmer": "^1.2.0",
+        "import-in-the-middle": "^1.8.1",
+        "require-in-the-middle": "^7.1.1",
+        "shimmer": "^1.2.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"


### PR DESCRIPTION
## Changes
### Telemetry

- instrumentation.ts — add RuntimeNodeInstrumentation to the OTel SDK, exporting event-loop delay/utilization, GC duration, and V8 heap metrics.
- metrics.ts — add self-contained gauges built only on Node built-ins (perf_hooks + process.memoryUsage), so they report even before the new dependency is installed: process.eventloop.lag.max / .p99 (ms) and process.memory.heap_used / .rss (bytes). The two event-loop gauges share one batched callback so both read the same snapshot before the histogram is reset each export window.
- package.json — declare @opentelemetry/instrumentation-runtime-node@^0.13.0 (aligned with the existing 0.56-era OTel stack; peer dep is only api ^1.3.0, which is satisfied).

### Infra (`infra/app/templates/backend.yaml`)

- NODE_OPTIONS=--max-old-space-size=1024 so V8 GCs at a predictable bound rather than growing toward node RAM.
- Memory request: 768Mi / limit: 1536Mi (heap cap plus headroom for zlib/buffers/native), CPU request: 500m, and no CPU limit (CFS throttling would stall the single event-loop thread).
- A livenessProbe deliberately more lenient than readiness (~150s before restart): transient lag de-registers a pod from the Service, but only a genuine multi-minute wedge restarts it.
