### PR TITLE
Fix "Open in Grades" in Catalog: pass courseId instead of courseNumber to fix mismatch

### DIFF
--- a/apps/frontend/src/app/Grades/index.tsx
+++ b/apps/frontend/src/app/Grades/index.tsx
@@ -32,6 +32,7 @@ import { type IGradeDistribution } from "@/lib/api";
 import { type ICourseWithInstructorClass } from "@/lib/api/courses";
 import { sortByTermDescending } from "@/lib/classes";
 import {
+  GetCourseNumberByIdDocument,
   GetGradeDistributionDocument,
   Semester,
   TemporalPosition,
@@ -59,16 +60,29 @@ const loadOutputsFromInputs = async (
   const results = await Promise.all(
     dedupedInputs.map(async (input) => {
       try {
-        const response = await client.query({
-          query: GetGradeDistributionDocument,
-          variables: input,
-        });
+        // The URL carries only courseId; resolve the human-readable course
+        // number so cards and edit/filter lookups don't run with an empty value.
+        const [response, courseResponse] = await Promise.all([
+          client.query({
+            query: GetGradeDistributionDocument,
+            variables: input,
+          }),
+          client
+            .query({
+              query: GetCourseNumberByIdDocument,
+              variables: { courseId: input.courseId },
+            })
+            .catch(() => null),
+        ]);
 
         if (!response.data?.grade) return null;
 
+        const courseNumber =
+          courseResponse?.data?.courseById?.number ?? input.courseNumber;
+
         return {
           data: response.data.grade,
-          input,
+          input: { ...input, courseNumber },
         };
       } catch {
         return null;

--- a/apps/frontend/src/components/Class/Grades/index.tsx
+++ b/apps/frontend/src/components/Class/Grades/index.tsx
@@ -30,7 +30,15 @@ const chartConfig = createChartConfig(["course"], {
 
 export default function Grades() {
   const {
-    class: { subject, courseNumber, number, semester, year, sessionId },
+    class: {
+      subject,
+      courseNumber,
+      courseId,
+      number,
+      semester,
+      year,
+      sessionId,
+    },
   } = useClass();
   const { data, loading } = useGetClassGrades(
     year,
@@ -102,7 +110,7 @@ export default function Grades() {
 
   const gradeExplorerUrl = useMemo(() => {
     const params = new URLSearchParams();
-    params.set("input", `${subject};${courseNumber}`);
+    params.set("input", `${subject};${courseId}`);
 
     if (typeof window !== "undefined") {
       try {
@@ -116,7 +124,7 @@ export default function Grades() {
     }
 
     return `/grades?${params.toString()}`;
-  }, [subject, courseNumber]);
+  }, [subject, courseId]);
 
   const subtitle = useMemo(() => {
     if (!courseTotal || courseTotal <= 0) return null;

--- a/apps/frontend/src/lib/api/courses.ts
+++ b/apps/frontend/src/lib/api/courses.ts
@@ -133,6 +133,14 @@ export const GET_COURSE_OVERVIEW_BY_ID = gql`
   }
 `;
 
+export const GET_COURSE_NUMBER_BY_ID = gql`
+  query GetCourseNumberById($courseId: CourseIdentifier!) {
+    courseById(courseId: $courseId) {
+      number
+    }
+  }
+`;
+
 export const GET_COURSE_GRADE_DIST = gql`
   query GetCourseGradeDist($subject: String!, $number: CourseNumber!) {
     course(subject: $subject, number: $number) {


### PR DESCRIPTION
## Issue:
<img width="728" height="696" alt="image" src="https://github.com/user-attachments/assets/a7422df7-8d69-4d52-947a-fd8ffb7e1b95" />
<img width="1463" height="728" alt="image" src="https://github.com/user-attachments/assets/2d58bfe6-d5b7-4af7-bb76-9a1957c5d7ac" /><br>

Another issue: When you open a class in grades and refresh, the name of the course is a blank string: 
<img width="1470" height="834" alt="image" src="https://github.com/user-attachments/assets/8c6d2b0b-30f1-4eb9-bff3-ceb1bb81c27e" />


### Root cause: 
#1130 changed the backend/frontend contract by adding courseId, but the "Open in Grades" button contract wasn't updated to match this. Instead courseNumber was passed in as courseId, which leads to no match. #1130 also changed the URL writer to not include course number, so on refresh the URL reader can't reconstruct the course number from the course ID in the url. 
### Fix:
1) Pass in courseId to the button
2) Add GetCourseNumberByIdDocument query