### PR TITLE
fix: pull FUTURE courses and dedupe to latest version

### DIFF
--- a/apps/datapuller/src/lib/courses.ts
+++ b/apps/datapuller/src/lib/courses.ts
@@ -158,14 +158,21 @@ export const getCourses = async (
     formatCourse
   );
 
-  const latestByKey = new Map<string, ICourseItem>();
+  const rank = (course: ICourseItem) => (course.status === "ACTIVE" ? 1 : 0);
+
+  const chosenByKey = new Map<string, ICourseItem>();
   for (const course of courses) {
     const courseKey = `${course.courseId}|${course.subject}|${course.number}`;
-    const existing = latestByKey.get(courseKey);
-    if (!existing || (course.fromDate ?? "") > (existing.fromDate ?? "")) {
-      latestByKey.set(courseKey, course);
+    const existing = chosenByKey.get(courseKey);
+    if (
+      !existing ||
+      rank(course) > rank(existing) ||
+      (rank(course) === rank(existing) &&
+        (course.fromDate ?? "") > (existing.fromDate ?? ""))
+    ) {
+      chosenByKey.set(courseKey, course);
     }
   }
 
-  return [...latestByKey.values()];
+  return [...chosenByKey.values()];
 };

--- a/apps/datapuller/src/lib/courses.ts
+++ b/apps/datapuller/src/lib/courses.ts
@@ -13,7 +13,7 @@ type CombinedCourse = Course & {
 };
 
 const filterCourse = (input: CombinedCourse): boolean => {
-  return input.status?.code === "ACTIVE";
+  return input.status?.code === "ACTIVE" || input.status?.code === "FUTURE";
 };
 
 const formatCourse = (input: CombinedCourse) => {
@@ -158,5 +158,14 @@ export const getCourses = async (
     formatCourse
   );
 
-  return courses;
+  const latestByKey = new Map<string, ICourseItem>();
+  for (const course of courses) {
+    const courseKey = `${course.courseId}|${course.subject}|${course.number}`;
+    const existing = latestByKey.get(courseKey);
+    if (!existing || (course.fromDate ?? "") > (existing.fromDate ?? "")) {
+      latestByKey.set(courseKey, course);
+    }
+  }
+
+  return [...latestByKey.values()];
 };


### PR DESCRIPTION
## Summary

The course datapuller dropped `FUTURE` (upcoming-term) courses, so classes pointing to
them never showed up in the catalog. Now keeps `ACTIVE` + `FUTURE`.

## Changes

- `filterCourse`: keep `ACTIVE` and `FUTURE`.
- `getCourses`: dedupe to newest `fromDate` per `{courseId, subject, number}`.