### PR TITLE
Set max memory limit = 140mb

### DIFF
--- a/infra/redis/values.yaml
+++ b/infra/redis/values.yaml
@@ -11,4 +11,6 @@ redis:
     persistence:
       enabled: false
     configuration: |
+      maxmemory 140mb
       maxmemory-policy volatile-lru
+      save ""


### PR DESCRIPTION
the `save ""` setting disables RDB snapshotting so that container restarts don't result in re-loading the data from disk every time (which is what is currently causing the repeated crashes)