### PR TITLE
fix: make curated classes findable by their real course number

### DIFF
--- a/apps/ag-frontend/src/app/CuratedClasses/index.tsx
+++ b/apps/ag-frontend/src/app/CuratedClasses/index.tsx
@@ -27,7 +27,7 @@ function Content({ curatedClasses }: ContentProps) {
 
   const fuzzySearch = useMemo(() => {
     const list = curatedClasses.map((c) => ({
-      name: `${c.subject} ${c.number}`,
+      name: `${c.subject} ${c.courseNumber}`,
       text: c.text,
       _id: c._id,
     }));

--- a/apps/ag-frontend/src/components/CuratedClassEditor/index.tsx
+++ b/apps/ag-frontend/src/components/CuratedClassEditor/index.tsx
@@ -83,7 +83,7 @@ export default function CuratedClassEditor({
     if (!classes?.catalog) return null;
 
     const list = classes.catalog.map((cls, index) => ({
-      name: `${cls.course.subject} ${cls.course.number}`,
+      name: `${cls.subject} ${cls.courseNumber}`,
       title: cls.title || cls.course.title || "",
       index,
     }));
@@ -108,8 +108,8 @@ export default function CuratedClassEditor({
     () =>
       classes?.catalog.find(
         (cls) =>
-          cls.course.subject === localValue.subject &&
-          cls.course.number === localValue.courseNumber &&
+          cls.subject === localValue.subject &&
+          cls.courseNumber === localValue.courseNumber &&
           cls.number === localValue.number &&
           cls.sessionId === localValue.sessionId
       ),
@@ -162,8 +162,8 @@ export default function CuratedClassEditor({
                 <Flex p="1" gap="3">
                   <Flex direction="column" flexGrow="1">
                     <Heading size="2">
-                      {selectedClass.course.subject}{" "}
-                      {selectedClass.course.number} #{selectedClass.number}
+                      {selectedClass.subject} {selectedClass.courseNumber} #
+                      {selectedClass.number}
                     </Heading>
                     <Text size="2" color="gray">
                       {selectedClass.title || selectedClass.course.title}
@@ -210,12 +210,12 @@ export default function CuratedClassEditor({
                 <Flex direction="column" gap="2">
                   {filteredClasses?.map((cls) => (
                     <Card
-                      key={`${cls.course.subject}-${cls.course.number}-${cls.number}-${cls.sessionId}`}
+                      key={`${cls.subject}-${cls.courseNumber}-${cls.number}-${cls.sessionId}`}
                       onClick={() =>
                         handleChange({
-                          subject: cls.course.subject,
+                          subject: cls.subject,
                           number: cls.number,
-                          courseNumber: cls.course.number,
+                          courseNumber: cls.courseNumber,
                           sessionId: cls.sessionId,
                         })
                       }
@@ -223,8 +223,7 @@ export default function CuratedClassEditor({
                       <Flex p="1" gap="3">
                         <Flex direction="column" flexGrow="1">
                           <Heading size="2">
-                            {cls.course.subject} {cls.course.number} #
-                            {cls.number}
+                            {cls.subject} {cls.courseNumber} #{cls.number}
                           </Heading>
                           <Text size="2" color="gray">
                             {cls.title || cls.course.title}

--- a/apps/ag-frontend/src/lib/api/classes.ts
+++ b/apps/ag-frontend/src/lib/api/classes.ts
@@ -366,6 +366,8 @@ export interface GetCatalogResponse {
 export const GET_CATALOG = gql`
   query GetCatalog($year: Int!, $semester: Semester!) {
     catalog(year: $year, semester: $semester) {
+      subject
+      courseNumber
       number
       sessionId
       title
@@ -393,8 +395,6 @@ export const GET_CATALOG = gql`
         }
       }
       course {
-        subject
-        number
         title
         gradeDistribution {
           average

--- a/apps/datapuller/src/lib/api/sis-api.ts
+++ b/apps/datapuller/src/lib/api/sis-api.ts
@@ -19,8 +19,24 @@ export async function fetchPaginatedData<
 ): Promise<T[]> {
   const results: T[] = [];
   const queryBatchSize = 50;
+  const maxAttempts = 3;
   let page = 1;
   let totalErrorCount = 0;
+
+  const isEndOfData = (error: any) =>
+    error?.status === 404 || error?.response?.status === 404;
+
+  const fetchPage = async (params: Record<string, any>) => {
+    for (let attempt = 1; ; attempt++) {
+      try {
+        const response: any = await api[method](params, { headers });
+        return responseProcessor(await response.json());
+      } catch (error: any) {
+        if (attempt >= maxAttempts || isEndOfData(error)) throw error;
+        await new Promise((resolve) => setTimeout(resolve, 500 * attempt));
+      }
+    }
+  };
 
   const fetchBatch = async (termId?: string) => {
     const promises = [];
@@ -36,14 +52,11 @@ export async function fetchPaginatedData<
       }
 
       promises.push(
-        api[method](params, { headers })
-          .then((response: any) => response.json())
-          .then((data: any) => responseProcessor(data))
-          .catch((error: any) => {
-            logger.warn(`Error fetching page ${page + i}: ${error.message}`);
-            errorCount++;
-            return [];
-          })
+        fetchPage(params).catch((error: any) => {
+          logger.warn(`Error fetching page ${page + i}: ${error.message}`);
+          errorCount++;
+          return [];
+        })
       );
     }
 

--- a/apps/datapuller/src/lib/api/sis-api.ts
+++ b/apps/datapuller/src/lib/api/sis-api.ts
@@ -23,16 +23,19 @@ export async function fetchPaginatedData<
   let page = 1;
   let totalErrorCount = 0;
 
+  const failedPages: number[] = [];
+
   const isEndOfData = (error: any) =>
     error?.status === 404 || error?.response?.status === 404;
 
-  const fetchPage = async (params: Record<string, any>) => {
+  const fetchPage = async (params: Record<string, any>): Promise<R[]> => {
     for (let attempt = 1; ; attempt++) {
       try {
         const response: any = await api[method](params, { headers });
         return responseProcessor(await response.json());
       } catch (error: any) {
-        if (attempt >= maxAttempts || isEndOfData(error)) throw error;
+        if (isEndOfData(error)) return [];
+        if (attempt >= maxAttempts) throw error;
         await new Promise((resolve) => setTimeout(resolve, 500 * attempt));
       }
     }
@@ -51,9 +54,12 @@ export async function fetchPaginatedData<
         params["term-id"] = termId;
       }
 
+      const pageNumber = page + i;
+
       promises.push(
         fetchPage(params).catch((error: any) => {
-          logger.warn(`Error fetching page ${page + i}: ${error.message}`);
+          logger.warn(`Error fetching page ${pageNumber}: ${error.message}`);
+          failedPages.push(pageNumber);
           errorCount++;
           return [];
         })
@@ -107,6 +113,12 @@ export async function fetchPaginatedData<
   }
 
   logger.warn(`Total errors encountered: ${totalErrorCount}`);
+
+  if (failedPages.length > 0) {
+    throw new Error(
+      `Incomplete fetch: ${failedPages.length} page(s) failed after ${maxAttempts} attempts: ${failedPages.join(", ")}`
+    );
+  }
 
   return results;
 }

--- a/apps/datapuller/src/pullers/courses.ts
+++ b/apps/datapuller/src/pullers/courses.ts
@@ -1,4 +1,4 @@
-import { CourseModel } from "@repo/common/models";
+import { CourseModel, ICourseItem } from "@repo/common/models";
 
 import { getCourses } from "../lib/courses";
 import { Config } from "../shared/config";
@@ -15,26 +15,37 @@ const updateCourses = async (config: Config) => {
 
   log.info(`Fetched ${courses.length.toLocaleString()} courses.`);
   if (courses.length === 0) {
-    log.error("No courses found, skipping update.");
-    return;
+    throw new Error("No courses found in SIS.");
   }
 
-  log.trace("Deleting courses no longer in SIS...");
+  log.trace("Deleting superseded course numbers...");
 
-  const previousCourses = await CourseModel.countDocuments();
+  const courseKey = ({
+    courseId,
+    subject,
+    number,
+  }: Pick<ICourseItem, "courseId" | "subject" | "number">) =>
+    `${courseId}|${subject}|${number}`;
 
-  if (courses.length / previousCourses <= 0.95) {
-    log.error(
-      `Fetched only ${courses.length} courses, while there were ${previousCourses} previous courses`
-    );
-    return;
-  }
+  const fetchedCourseIds = [
+    ...new Set(courses.map((course) => course.courseId)),
+  ];
+  const fetchedKeys = new Set(courses.map(courseKey));
 
-  const { deletedCount } = await CourseModel.deleteMany({
-    courseId: { $nin: courses.map((course) => course.courseId) },
-  });
+  const storedCourses = await CourseModel.find(
+    { courseId: { $in: fetchedCourseIds } },
+    { courseId: 1, subject: 1, number: 1 }
+  ).lean();
 
-  log.info(`Deleted ${deletedCount.toLocaleString()} courses.`);
+  const supersededIds = storedCourses
+    .filter((course) => !fetchedKeys.has(courseKey(course)))
+    .map((course) => course._id);
+
+  const { deletedCount } = supersededIds.length
+    ? await CourseModel.deleteMany({ _id: { $in: supersededIds } })
+    : { deletedCount: 0 };
+
+  log.info(`Deleted ${deletedCount.toLocaleString()} superseded courses.`);
 
   // Insert courses in batches of 5000
   const insertBatchSize = 5000;


### PR DESCRIPTION
Advisors reported that MUSIC 32, INTEGBI 130 and EALANG 121 could not be added in the Curated Classes tool. These turned out to be two unrelated bugs, plus a third found while verifying.

All three classes and their primary sections exist in `classes`/`sections` for Fall 2026. What breaks is the join to `courses`, which both catalog paths perform by `courseId`.

## 1. The tool identified classes by the course record

`CuratedClassEditor` took `subject`/`courseNumber` from the joined **course**, not the class. SIS renumbered `courseId 111172` from INTEGBI 32 to INTEGBI 130 effective 2026-08-19, carried only on the course's FUTURE version, so the class showed up as "INTEGBI 32" and was unfindable by its real number.

This is wider than renumbers. In Spring 2026 alone, **371 of 16,086 classes** have a class-level subject/number differing from the joined course record — mostly cross-listings. Running the editor's own search over that data:

```
"AFRICAM C143A"  before: (no results)          after: AFRICAM C143A #001
"AMERSTD C152"   before: (no results)          after: AMERSTD C152 #001
"THEATER C183A"  before: AFRICAM C143A #001    after: (no results)
```

It also affected saving: those values are written into the curated class, and the backend resolves them against `ClassModel`, so an entry saved as "INTEGBI 32" would never have resolved.

The list page had a matching bug — rows render `{subject} {courseNumber}` but the search index was built from `{subject} {number}`, the *section* number, so no course number ever matched ("EALANG C120" found nothing; "EALANG 001" found it).

## 2. The courses puller has not written anything in months

The puller fetches ACTIVE/FUTURE courses, then deleted every stored course whose `courseId` was absent from that fetch — 42,304 of 58,399 docs, including 10,336 courseIds still referenced by past-term classes. A ratio guard stood in front of it and returned early whenever the fetch was under 95% of `countDocuments()`. The collection holds one doc per `(courseId, subject, number)` while the fetch is deduped to current numbers, so the ratio sits at 16,254/58,399 = **0.28** and the guard aborted every run, silently, exit code 0. That is why no course created since has ever landed, including MUSIC 32 (courseId 168547) and EALANG 121 (168502).

Now it deletes only superseded numbers — docs whose `courseId` is in the fetch but whose `(courseId, subject, number)` is not — which clears leftovers like COLWRIT 6A once COLWRIT 22B lands, while keeping discontinued courses so past-term joins survive. With nothing destructive left to guard, the ratio check goes away. Failures now throw so the CronJob fails visibly instead of reporting success without writing. Page fetches also retry 3x with backoff before counting as errors, since a dropped page silently truncates the list.

## Verification

Ran against local Mongo:

```
Fetched 16,254 courses.
Deleted 111 superseded courses.
Completed updating database with 16,254 courses.
```

`courses` went 58,399 -> 58,558; INTEGBI 130, MUSIC 32, EALANG 121 and ARCH 101B all present, history intact. Also verified on an empty collection (guard skipped, 0 deleted, 16,254 upserted). Confirmed against SIS that all three classes' primary sections have `printInScheduleOfClasses: true`, so they clear the stricter filter the denormalized catalog applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
