### PR TITLE
Route /nav-item through the ingress to the backend

### DIFF
--- a/infra/app/templates/ingress.yaml
+++ b/infra/app/templates/ingress.yaml
@@ -53,6 +53,13 @@ spec:
                 name: {{ include "bt-app.backendName" . }}-svc
                 port:
                   number: {{ .Values.port }}
+          - path: /nav-item
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "bt-app.backendName" . }}-svc
+                port:
+                  number: {{ .Values.port }}
           {{- if .Values.otel.enabled }}
           - path: /otlp
             pathType: Prefix


### PR DESCRIPTION
## Problem

Nav item clicks in production were both untracked (staff dashboard showed 0 clicks) and intermittently broken — sometimes landing on `https://berkeleytime.com/nav-item/click/<id>` with a 404 instead of the destination.

`infra/app/templates/ingress.yaml` forwards `/go`, `/banner`, and `/message` to the backend service, but not `/nav-item`. Everything else falls through to the frontend, so requests to the click-tracking redirect (`apps/backend/src/modules/nav-item/routes.ts`) were served the SPA's `index.html`, which has no matching route and renders its 404 page. The handler never ran, so no redirect happened and `clickCount` was never incremented.

Confirmed against production:

```
/nav-item/click/<id>                    -> 200, text/html (SPA index.html)
/banner/click/000000000000000000000000  -> 302 -> https://berkeleytime.com/  (reaches backend)
```

Local dev was unaffected because `nginx.conf` already proxies `/nav-item/` to the backend, which is why this wasn't caught before deploy.

The intermittency comes from `FALLBACK_NAV_ITEMS` in `apps/frontend/src/components/NavigationBar/index.tsx`: while the `allNavItems` query is in flight (or if it fails), the nav link points straight at `BERKELEY_GOGGLES_URL`. Clicking in that window works but tracks nothing; clicking after the query resolves hits the broken redirect. The fallback is left as-is here.

## Change

Adds a `/nav-item` prefix path to the ingress, mirroring the existing `/banner` and `/message` entries.

## Testing

Not rendered with helm (not installed locally); the added block is a literal copy of the `/message` entry with the path changed. Takes effect on the next prod deploy — after that, `/nav-item/click/<id>` should 302 to the destination and increment `clickCount`.

Historical clicks are unrecoverable: those requests never reached the backend, so there is nothing to backfill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)