### PR TITLE
Fix catalog sort being ignored while a search query is active

### DIFF
--- a/apps/backend/src/modules/catalog/controller.ts
+++ b/apps/backend/src/modules/catalog/controller.ts
@@ -121,6 +121,8 @@ export const getCatalogSearch = async (params: CatalogQueryParams) => {
       semester,
       searchTerm: search.trim(),
       filters,
+      sortBy,
+      sortOrder,
       limit: effectivePageSize,
       skip,
     });
@@ -202,6 +204,8 @@ const getCatalogWithSearch = async ({
   semester,
   searchTerm,
   filters,
+  sortBy,
+  sortOrder,
   limit,
   skip,
 }: {
@@ -209,17 +213,52 @@ const getCatalogWithSearch = async ({
   semester: string;
   searchTerm: string;
   filters: CatalogQueryParams["filters"];
+  sortBy?: string | null;
+  sortOrder?: string | null;
   limit: number;
   skip: number;
 }) => {
   const index = await getSearchIndex(year, semester);
   const hits = index.search(searchTerm);
   const items = hits.map((r) => r.item);
-  const filtered = applyInMemoryFilters(items, filters);
+  const filtered = sortSearchResults(
+    applyInMemoryFilters(items, filters),
+    sortBy,
+    sortOrder
+  );
   const totalCount = filtered.length;
   const results = filtered.slice(skip, skip + limit);
 
   return { results, totalCount };
+};
+
+type NumericSortField = "unitsMax" | "allTimeAverageGrade" | "openSeats";
+
+const SEARCH_SORT_FIELD_MAP: Record<string, NumericSortField> = {
+  UNITS: "unitsMax",
+  AVERAGE_GRADE: "allTimeAverageGrade",
+  OPEN_SEATS: "openSeats",
+};
+
+const sortSearchResults = (
+  items: ICatalogClassItem[],
+  sortBy?: string | null,
+  sortOrder?: string | null
+): ICatalogClassItem[] => {
+  const field = sortBy ? SEARCH_SORT_FIELD_MAP[sortBy] : undefined;
+  if (!field) return items;
+
+  const order = sortOrder === "ASC" ? 1 : -1;
+
+  return [...items].sort((a, b) => {
+    const diff = (a[field] ?? 0) - (b[field] ?? 0);
+    if (diff !== 0) return diff * order;
+    if (a.subject !== b.subject) return a.subject < b.subject ? -1 : 1;
+    if (a.courseNumber !== b.courseNumber) {
+      return a.courseNumber < b.courseNumber ? -1 : 1;
+    }
+    return 0;
+  });
 };
 
 const applyInMemoryFilters = (

--- a/apps/frontend/src/components/ClassBrowser/hooks/useCatalogQuery.ts
+++ b/apps/frontend/src/components/ClassBrowser/hooks/useCatalogQuery.ts
@@ -122,8 +122,8 @@ export default function useCatalogQuery({
       semester: currentSemester,
       search: debouncedQuery || undefined,
       filters: filterVariables,
-      sortBy: debouncedQuery ? undefined : mapSortBy(sortBy),
-      sortOrder: debouncedQuery ? undefined : mapSortOrder(effectiveOrder),
+      sortBy: mapSortBy(sortBy),
+      sortOrder: mapSortOrder(effectiveOrder),
       semanticSearch: semanticSearch || undefined,
     }),
     [


### PR DESCRIPTION
## Problem

I noticed that sorting by units/average grade/open seats did nothing whenever you had an active search query. Sorting in the catalog only worked when the search box was empty. As soon as any search text was entered, the Sort By dropdown kept updating and the URL would change to reflect whatever was put in, but it didn't actually do anything. At least for me, that got rid of most of the utility of the search function.

## Root cause

- Looking back at the commit history, I noticed that it seemed to be tied to an old implementation of search (PR #1101 built the search path on MongoDB Atlas $search) that didn't support search + sort.
- PR #1102 changed things to switch out the Atlas $search for a Fuse.js in-memory index, but the workaround wasn't changed, which meant search + sort stayed inactive even when it didn't seem necessary anymore.
- useCatalogQuery made sortBy/sortOrder undefined whenever there was a search query, and either way, the new(ish) Fuse.js search path (getCatalogWithSearch) never applied a sort to begin with.

## Fix

- useCatalogQuery will now always send sort state
- Sort happens between filtering and pagination so that following pages will be correct
- Tie-break by subject/courseNumber, which is the same tiebreaking methodology that regular non-search buildSort already uses
- When sorting by relevance, it doesn't actually sort by relevance, which doesn't exist, it just keeps Fuse's ordering by how well the output matches the query

## Testing

- I type-checked and linted the code
- I ran the page & dev stack (Docker: Mongo/Redis/backend/frontend) locally on my laptop with synthetic data since I didn't have access to actually query for real data, and it worked as expected
- I didn't see any test coverage for this code, so I didn't add any