### PR TITLE
Renamed Courses: Find a Course by Its Old Name

### DIFF
--- a/apps/backend/src/modules/catalog/catalog-cache.ts
+++ b/apps/backend/src/modules/catalog/catalog-cache.ts
@@ -1,6 +1,8 @@
 import { FuzzySearch } from "@repo/common";
 import { CatalogClassModel, type ICatalogClassItem } from "@repo/common/models";
 
+import { getFormerNamesByCourseId } from "../course/controller";
+
 const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
 const MAX_CACHE_ENTRIES = 5;
 
@@ -71,8 +73,24 @@ export const getSearchIndex = async (
   }
 
   const data = await getCachedCatalog(year, semester);
+  const formerNamesByCourseId = await getFormerNamesByCourseId();
 
-  const index = new FuzzySearch<ICatalogClassItem>(data, {
+  const indexedData = data.map((item) => {
+    const formerNames = formerNamesByCourseId.get(item.courseId);
+    if (!formerNames?.length) return item;
+
+    const formerNameVariants = formerNames.flatMap((name) => [
+      name,
+      name.replace(/\s+/g, ""),
+    ]);
+
+    return {
+      ...item,
+      searchableNames: [...(item.searchableNames ?? []), ...formerNameVariants],
+    };
+  });
+
+  const index = new FuzzySearch<ICatalogClassItem>(indexedData, {
     keys: [
       { name: "searchableNames", weight: 10 },
       { name: "courseTitle", weight: 2 },

--- a/apps/backend/src/modules/course/controller.ts
+++ b/apps/backend/src/modules/course/controller.ts
@@ -40,17 +40,38 @@ const buildFormerNamesByCourseId = async () => {
   );
 };
 
-let formerNamesByCourseIdCache: Promise<Map<string, string[]>> | null = null;
+const FORMER_NAMES_CACHE_TTL_MS = 5 * 60 * 1000;
+
+interface FormerNamesCacheEntry {
+  promise: Promise<Map<string, string[]>>;
+  expiresAt: number;
+}
+
+let formerNamesByCourseIdCache: FormerNamesCacheEntry | null = null;
 
 export const getFormerNamesByCourseId = () => {
-  formerNamesByCourseIdCache ??= buildFormerNamesByCourseId().catch(
-    (error) => {
-      formerNamesByCourseIdCache = null;
-      throw error;
-    }
-  );
+  const now = Date.now();
 
-  return formerNamesByCourseIdCache;
+  if (
+    formerNamesByCourseIdCache &&
+    now < formerNamesByCourseIdCache.expiresAt
+  ) {
+    return formerNamesByCourseIdCache.promise;
+  }
+
+  const entry: FormerNamesCacheEntry = {
+    promise: buildFormerNamesByCourseId(),
+    expiresAt: now + FORMER_NAMES_CACHE_TTL_MS,
+  };
+  formerNamesByCourseIdCache = entry;
+
+  void entry.promise.catch(() => {
+    if (formerNamesByCourseIdCache === entry) {
+      formerNamesByCourseIdCache = null;
+    }
+  });
+
+  return entry.promise;
 };
 
 export const getCourse = async (subject: string, number: string) => {

--- a/apps/backend/src/modules/course/controller.ts
+++ b/apps/backend/src/modules/course/controller.ts
@@ -42,7 +42,7 @@ const buildFormerNamesByCourseId = async () => {
 
 let formerNamesByCourseIdCache: Promise<Map<string, string[]>> | null = null;
 
-const getFormerNamesByCourseId = () => {
+export const getFormerNamesByCourseId = () => {
   formerNamesByCourseIdCache ??= buildFormerNamesByCourseId().catch(
     (error) => {
       formerNamesByCourseIdCache = null;

--- a/apps/backend/src/modules/course/controller.ts
+++ b/apps/backend/src/modules/course/controller.ts
@@ -10,6 +10,49 @@ import { formatClass } from "../class/formatter";
 import { IntermediateCourse, formatCourse } from "./formatter";
 import { CourseModule } from "./generated-types/module-types";
 
+const buildFormerNamesByCourseId = async () => {
+  const classNames = await ClassModel.aggregate<{
+    _id: string;
+    names: string[];
+  }>([
+    {
+      $group: {
+        _id: "$courseId",
+        names: { $addToSet: { $concat: ["$subject", " ", "$courseNumber"] } },
+      },
+    },
+  ]);
+
+  const currentCourses = await CourseModel.find(
+    { printInCatalog: true },
+    { subject: 1, number: 1 }
+  ).lean();
+
+  const currentCourseNames = new Set(
+    currentCourses.map((c) => `${c.subject} ${c.number}`)
+  );
+
+  return new Map(
+    classNames.map(({ _id, names }) => [
+      _id,
+      names.filter((name) => !currentCourseNames.has(name)),
+    ])
+  );
+};
+
+let formerNamesByCourseIdCache: Promise<Map<string, string[]>> | null = null;
+
+const getFormerNamesByCourseId = () => {
+  formerNamesByCourseIdCache ??= buildFormerNamesByCourseId().catch(
+    (error) => {
+      formerNamesByCourseIdCache = null;
+      throw error;
+    }
+  );
+
+  return formerNamesByCourseIdCache;
+};
+
 export const getCourse = async (subject: string, number: string) => {
   const course = await CourseModel.findOne({
     subject: buildSubjectQuery(subject),
@@ -20,7 +63,12 @@ export const getCourse = async (subject: string, number: string) => {
 
   if (!course) return null;
 
-  return formatCourse(course as ICourseItem);
+  const formerNamesByCourseId = await getFormerNamesByCourseId();
+
+  return {
+    ...formatCourse(course as ICourseItem),
+    formerNames: formerNamesByCourseId.get(course.courseId) ?? [],
+  };
 };
 
 export const getCourseById = async (
@@ -39,7 +87,12 @@ export const getCourseById = async (
       .lean();
 
     if (exactMatch) {
-      return formatCourse(exactMatch as ICourseItem);
+      const formerNamesByCourseId = await getFormerNamesByCourseId();
+
+      return {
+        ...formatCourse(exactMatch as ICourseItem),
+        formerNames: formerNamesByCourseId.get(courseId) ?? [],
+      };
     }
   }
 
@@ -50,7 +103,12 @@ export const getCourseById = async (
 
   if (!course) return null;
 
-  return formatCourse(course as ICourseItem);
+  const formerNamesByCourseId = await getFormerNamesByCourseId();
+
+  return {
+    ...formatCourse(course as ICourseItem),
+    formerNames: formerNamesByCourseId.get(courseId) ?? [],
+  };
 };
 
 interface GetClassesByCourseOptions {
@@ -205,9 +263,12 @@ export const getCourses = async () => {
   //   }
   // }
 
+  const formerNamesByCourseId = await getFormerNamesByCourseId();
+
   return courses.map((c) => ({
     ...formatCourse(c),
     gradeDistribution: null,
+    formerNames: formerNamesByCourseId.get(c.courseId) ?? [],
   })) as (Exclude<IntermediateCourse, "gradeDistribution"> & {
     gradeDistribution: CourseModule.Course["gradeDistribution"];
   })[];

--- a/apps/frontend/src/components/CourseSearch/browser.ts
+++ b/apps/frontend/src/components/CourseSearch/browser.ts
@@ -2,16 +2,32 @@ import { FuzzySearch } from "@repo/common";
 
 import { SUBJECT_NICKNAME_MAP } from "@/lib/departmentNicknames";
 
+const getFormerNameVariants = (formerDisplayName: string): string[] => {
+  const words = formerDisplayName.trim().split(/\s+/);
+  const formerNumber = words[words.length - 1];
+  const formerSubject = words.slice(0, -1).join("");
+
+  if (!formerSubject) return [formerDisplayName.trim()];
+
+  return [
+    formerDisplayName.trim(),
+    `${formerSubject} ${formerNumber}`,
+    `${formerSubject}${formerNumber}`,
+  ];
+};
+
 export const initialize = (
   courses: {
     title: string;
     subject: string;
     departmentNicknames?: string | null;
+    formerDisplayName?: string | null;
     number: string;
   }[]
 ) => {
   const list = courses.map((course) => {
-    const { title, subject, departmentNicknames, number } = course;
+    const { title, subject, departmentNicknames, formerDisplayName, number } =
+      course;
 
     const containsPrefix = /^[a-zA-Z].*/.test(number);
     const alternateNumber = number.slice(1);
@@ -31,30 +47,35 @@ export const initialize = (
       ...new Set([...sisNicknames, ...hardcodedNicknames]),
     ];
 
-    const alternateNames = abbreviations.reduce(
-      (acc, abbreviation) => {
-        const abbrevs = [
-          `${abbreviation}${number}`,
-          `${abbreviation} ${number}`,
-        ];
+    const alternateNames = [
+      ...abbreviations.reduce(
+        (acc, abbreviation) => {
+          const abbrevs = [
+            `${abbreviation}${number}`,
+            `${abbreviation} ${number}`,
+          ];
 
-        if (containsPrefix) {
-          abbrevs.push(
-            `${abbreviation}${alternateNumber}`,
-            `${abbreviation} ${alternateNumber}`
-          );
-        }
+          if (containsPrefix) {
+            abbrevs.push(
+              `${abbreviation}${alternateNumber}`,
+              `${abbreviation} ${alternateNumber}`
+            );
+          }
 
-        return [...acc, ...abbrevs];
-      },
-      containsPrefix
-        ? [
-            `${subject}${number}`,
-            `${subject} ${alternateNumber}`,
-            `${subject}${alternateNumber}`,
-          ]
-        : [`${subject}${number}`]
-    );
+          return [...acc, ...abbrevs];
+        },
+        containsPrefix
+          ? [
+              `${subject}${number}`,
+              `${subject} ${alternateNumber}`,
+              `${subject}${alternateNumber}`,
+            ]
+          : [`${subject}${number}`]
+      ),
+      ...(formerDisplayName?.trim()
+        ? getFormerNameVariants(formerDisplayName)
+        : []),
+    ];
 
     return {
       title,

--- a/apps/frontend/src/components/CourseSearch/browser.ts
+++ b/apps/frontend/src/components/CourseSearch/browser.ts
@@ -2,31 +2,17 @@ import { FuzzySearch } from "@repo/common";
 
 import { SUBJECT_NICKNAME_MAP } from "@/lib/departmentNicknames";
 
-const getFormerNameVariants = (formerDisplayName: string): string[] => {
-  const words = formerDisplayName.trim().split(/\s+/);
-  const formerNumber = words[words.length - 1];
-  const formerSubject = words.slice(0, -1).join("");
-
-  if (!formerSubject) return [formerDisplayName.trim()];
-
-  return [
-    formerDisplayName.trim(),
-    `${formerSubject} ${formerNumber}`,
-    `${formerSubject}${formerNumber}`,
-  ];
-};
-
 export const initialize = (
   courses: {
     title: string;
     subject: string;
     departmentNicknames?: string | null;
-    formerDisplayName?: string | null;
+    formerNames?: string[] | null;
     number: string;
   }[]
 ) => {
   const list = courses.map((course) => {
-    const { title, subject, departmentNicknames, formerDisplayName, number } =
+    const { title, subject, departmentNicknames, formerNames, number } =
       course;
 
     const containsPrefix = /^[a-zA-Z].*/.test(number);
@@ -72,9 +58,12 @@ export const initialize = (
             ]
           : [`${subject}${number}`]
       ),
-      ...(formerDisplayName?.trim()
-        ? getFormerNameVariants(formerDisplayName)
-        : []),
+      ...(formerNames ?? [])
+        .filter(Boolean)
+        .flatMap((formerName) => [
+          formerName,
+          formerName.replace(/\s+/g, ""),
+        ]),
     ];
 
     return {

--- a/apps/frontend/src/lib/api/courses.ts
+++ b/apps/frontend/src/lib/api/courses.ts
@@ -217,7 +217,7 @@ export const GET_COURSE_NAMES = gql`
       courseId
       subject
       departmentNicknames
-      formerDisplayName
+      formerNames
       number
       title
     }

--- a/apps/frontend/src/lib/api/courses.ts
+++ b/apps/frontend/src/lib/api/courses.ts
@@ -217,6 +217,7 @@ export const GET_COURSE_NAMES = gql`
       courseId
       subject
       departmentNicknames
+      formerDisplayName
       number
       title
     }

--- a/packages/gql-typedefs/course.ts
+++ b/packages/gql-typedefs/course.ts
@@ -36,6 +36,7 @@ export const courseTypeDef = gql`
     academicOrganizationName: String
     departmentNicknames: String
     formerDisplayName: String
+    formerNames: [String!]!
     title: String!
     primaryInstructionMethod: InstructionMethod!
     toDate: String!

--- a/packages/gql-typedefs/course.ts
+++ b/packages/gql-typedefs/course.ts
@@ -35,6 +35,7 @@ export const courseTypeDef = gql`
     academicOrganization: String
     academicOrganizationName: String
     departmentNicknames: String
+    formerDisplayName: String
     title: String!
     primaryInstructionMethod: InstructionMethod!
     toDate: String!

--- a/packages/gql-typedefs/course.ts
+++ b/packages/gql-typedefs/course.ts
@@ -36,7 +36,7 @@ export const courseTypeDef = gql`
     academicOrganizationName: String
     departmentNicknames: String
     formerDisplayName: String
-    formerNames: [String!]!
+    formerNames: [String!]! @cacheControl(maxAge: 300, scope: PUBLIC)
     title: String!
     primaryInstructionMethod: InstructionMethod!
     toDate: String!


### PR DESCRIPTION
## What changed

The university sometimes renames a course. For example, "EECS 16A" became "ELENG 66" starting Fall 2026. Students who knew the old name had no way to find the course: typing "EECS 16A" into a course search brought up unrelated courses, and the renamed class looked like it had vanished.

Now, searching the old name finds the renamed course. This works in the course picker on the Enrollment and Grades pages and in the Catalog search.

| | Before | After |
|---|---|---|
| Course picker (Enrollment/Grades), searching the old name "EECS 16A" | ![Before: only an unrelated course comes up](https://gist.githubusercontent.com/NathanDai5287/aeed2d28467885549e145707d1c46314/raw/1162-before-enrollment.png) | ![After: ELENG 66 is the top suggestion](https://gist.githubusercontent.com/NathanDai5287/aeed2d28467885549e145707d1c46314/raw/1162-after-enrollment.png) |
| Catalog search (Fall 2026), searching "EECS 16A" | ![Before: ELENG 66 is missing from results](https://gist.githubusercontent.com/NathanDai5287/aeed2d28467885549e145707d1c46314/raw/1162-before-catalog.png) | ![After: ELENG 66 is the top result](https://gist.githubusercontent.com/NathanDai5287/aeed2d28467885549e145707d1c46314/raw/1162-after-catalog.png) |

## Test plan

- [ ] Search "EECS 16A" in the Enrollment or Grades course picker → ELENG 66 appears and can be selected
- [ ] Search "EECS 16A" in the Catalog with the Fall 2026 term selected → ELENG 66 is the top result
- [ ] Search courses by their current names → results unchanged