### PR TITLE
Enrollment: Keep Semester Selected When Editing a Course

### DIFF
--- a/apps/frontend/src/app/Enrollment/index.tsx
+++ b/apps/frontend/src/app/Enrollment/index.tsx
@@ -316,7 +316,7 @@ function EnrollmentSidebar({
     [selectedSemesterValue]
   );
   useEffect(() => {
-    if (!selectedCourse) return;
+    if (!selectedCourse || courseLoading) return;
 
     if (semesterOptions.length === 0) {
       if (selectedSemesterValue !== null) {
@@ -332,7 +332,7 @@ function EnrollmentSidebar({
     ) {
       setSelectedSemesterValue(null);
     }
-  }, [selectedCourse, selectedSemesterValue, semesterOptions]);
+  }, [selectedCourse, courseLoading, selectedSemesterValue, semesterOptions]);
 
   const availableClasses = useMemo(() => {
     if (!selectedSemester) return [];


### PR DESCRIPTION
## What changed

The enrollment page lets students chart how enrollment in a course changes over time. Each graphed course has an "Edit course" button that opens a sidebar where you can change that entry's semester or color.

**The problem:** when you clicked "Edit course", the sidebar opened with your semester still selected — but a moment later, while the course's details loaded in the background, the semester reset to empty. To make any edit, you had to pick the semester again.

**Now:** the semester you originally picked stays selected the whole time the sidebar is open, so you can edit right away.

| | Before | After |
|---|---|---|
| Edit sidebar right after clicking "Edit course" | ![Before: the semester resets to "Select semester"](https://gist.githubusercontent.com/NathanDai5287/0cdef33052432bd8b44b0c49cf4e78dc/raw/bug-on-main.png) | ![After: the semester stays "Fall 2025"](https://gist.githubusercontent.com/NathanDai5287/0cdef33052432bd8b44b0c49cf4e78dc/raw/fix-verified.png) |

## Test plan

- [ ] On the enrollment page, add a course (e.g. COMPSCI 61A, Fall 2025) to the chart
- [ ] Reload the page, then click "Edit course" on the graphed entry
- [ ] Confirm the semester stays selected ("Fall 2025") while the sidebar finishes loading
- [ ] Change the semester or color and save; confirm the entry updates

Made with [Cursor](https://cursor.com)