### PR TITLE
Fix missing axe-core dependency in Storybook build

### DIFF
--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -7,18 +7,21 @@
     "dev": "storybook dev -p 6006 --no-open"
   },
   "dependencies": {
-    "@repo/theme": "*",
     "@chromatic-com/storybook": "^4.1.1",
+    "@repo/theme": "*",
     "@storybook/addon-a11y": "^9.1.10",
     "@storybook/addon-docs": "^9.1.10",
     "@storybook/addon-vitest": "^9.1.10",
     "@storybook/react-vite": "^9.1.10",
     "@types/papaparse": "^5.3.16",
+    "@vitest/browser": "^3.2.4",
+    "@vitest/coverage-v8": "^3.2.4",
+    "playwright": "^1.56.0",
     "prop-types": "^15.8.1",
     "storybook": "^9.1.10",
-    "vitest": "^3.2.4",
-    "@vitest/browser": "^3.2.4",
-    "playwright": "^1.56.0",
-    "@vitest/coverage-v8": "^3.2.4"
+    "vitest": "^3.2.4"
+  },
+  "devDependencies": {
+    "axe-core": "^4.13.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -389,6 +389,9 @@
         "prop-types": "^15.8.1",
         "storybook": "^9.1.10",
         "vitest": "^3.2.4"
+      },
+      "devDependencies": {
+        "axe-core": "^4.13.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -11465,6 +11468,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.13.0.tgz",
+      "integrity": "sha512-UzGt8zg7Ny8djbYMhxl2zuEevVa7r2gJjYY5Lwr1xM7+XU2nd6CkIWFTVcCIbAP63vSz71NaVyyuSk9lHKcy0A==",
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/b4a": {


### PR DESCRIPTION
## Summary

- add `axe-core` explicitly to the Storybook workspace
- update the lockfile so clean Storybook builds can resolve the accessibility engine used by `@storybook/addon-a11y`

## Context

This was split out of #1166 because it is unrelated to the `/apply` page.