### PR TITLE
Fix additional nav item color to match built-in nav items

### DIFF
--- a/apps/frontend/src/components/NavigationBar/NavigationBar.module.scss
+++ b/apps/frontend/src/components/NavigationBar/NavigationBar.module.scss
@@ -41,11 +41,6 @@
   align-items: center;
 }
 
-.extraItem.extraItem {
-  color: var(--heading-color);
-  font-weight: var(--font-semibold);
-}
-
 .extraItemLabel {
   display: inline-flex;
   align-items: center;
@@ -172,10 +167,6 @@
           top: -12px;
           background-color: white;
         }
-      }
-
-      &.extraItem {
-        color: white;
       }
     }
 

--- a/apps/frontend/src/components/NavigationBar/index.tsx
+++ b/apps/frontend/src/components/NavigationBar/index.tsx
@@ -295,7 +295,7 @@ export default function NavigationBar({
               href={navItem.href}
               target="_blank"
               rel="noopener noreferrer"
-              className={classNames(styles.item, styles.extraItem)}
+              className={styles.item}
             >
               <span className={styles.extraItemLabel}>
                 {navItem.label}


### PR DESCRIPTION
## Summary
- Staff-added extra nav items (e.g. "Clubs") had a `color`/`font-weight` override in `NavigationBar.module.scss` that made them bolder and a different color than the built-in nav items (Catalog, Scheduler, etc.)
- Removed the override so extra nav items use the same `MenuItem` styling (paragraph color by default, heading color on hover/active) as the rest of the nav, in both light and dark/invert mode

## Screenshots
<img width="496" height="43" alt="Screenshot 2026-08-27 at 10 29 49 AM" src="https://github.com/user-attachments/assets/88e4a313-c375-4b50-997d-5a0e04778162" />
<img width="507" height="36" alt="Screenshot 2026-08-27 at 10 29 53 AM" src="https://github.com/user-attachments/assets/414d6302-26ee-4908-971d-3173f1213d84" />


## Test plan
- [x] `tsc --noEmit` passes
- [x] Visually confirm extra nav items (e.g. "Clubs") match the color/weight of other nav items in light mode
- [x] Visually confirm the same in dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)