### PR TITLE
Hide recruitment banner on Apply page

### DIFF
--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -173,14 +173,6 @@ const router = createBrowserRouter([
             ),
           },
           {
-            path: "apply",
-            element: (
-              <SuspenseBoundary key="apply">
-                <Apply />
-              </SuspenseBoundary>
-            ),
-          },
-          {
             path: "legal/privacy",
             element: (
               <SuspenseBoundary key="privacy">
@@ -193,6 +185,19 @@ const router = createBrowserRouter([
             element: (
               <SuspenseBoundary key="terms">
                 <Terms />
+              </SuspenseBoundary>
+            ),
+          },
+        ],
+      },
+      {
+        element: <Layout banner={false} />,
+        children: [
+          {
+            path: "apply",
+            element: (
+              <SuspenseBoundary key="apply">
+                <Apply />
               </SuspenseBoundary>
             ),
           },


### PR DESCRIPTION
## Summary
- keep the standard navigation and footer on \/apply\`n- suppress the global outreach banner on that page so it does not advertise the page from within itself

## Verification
- \
pm run type-check --workspace=apps/frontend\`n- headless Chromium check confirmed Apply content and navigation remain visible while the recruitment banner is absent