### PR TITLE
Update coffee chat Airtable embed

### DIFF
--- a/apps/frontend/src/app/Apply/Apply.module.scss
+++ b/apps/frontend/src/app/Apply/Apply.module.scss
@@ -141,13 +141,13 @@
 .coffeeChatsEmbed {
   width: 100%;
   max-width: 900px;
-  height: 600px;
+  height: 1200px;
   border: 1px solid var(--border-color);
   border-radius: 12px;
   background-color: var(--foreground-color);
 
   @media (max-width: 768px) {
-    height: 480px;
+    height: 960px;
   }
 }
 

--- a/apps/frontend/src/app/Apply/index.tsx
+++ b/apps/frontend/src/app/Apply/index.tsx
@@ -15,9 +15,9 @@ import styles from "./Apply.module.scss";
 
 const APPLICATION_FORM_URL = "https://forms.gle/kUtzz74eeV8BiMKw6";
 const COFFEE_CHATS_URL =
-  "https://airtable.com/appLBtO52VOJBy6Mf/shrW4DKqjbvk15uXq";
+  "https://airtable.com/appS2E6oOWx3AeOmx/shrTOrgzZCdPK5Czv";
 const COFFEE_CHATS_EMBED_URL =
-  "https://airtable.com/embed/appLBtO52VOJBy6Mf/shrW4DKqjbvk15uXq";
+  "https://airtable.com/embed/appS2E6oOWx3AeOmx/shrTOrgzZCdPK5Czv";
 
 const ROLES = [
   {


### PR DESCRIPTION
## Summary

- point the Apply page at the Spring 2026 coffee chat Airtable view
- double the desktop embed height from 600px to 1200px
- double the mobile embed height from 480px to 960px

## Verification

- confirmed both the public Airtable link and embed URL return successfully
- frontend type-check passed
- frontend lint passed with 12 pre-existing Fast Refresh warnings
- full pre-push checks passed: type-check, formatting, lint, Playwright sanity/API tests, and production build