### PR TITLE
Collapse GradTrak domain emphases by default + fix vertical spacing 

### DIFF
--- a/apps/frontend/src/app/GradTrak/BtLLInterface/BtLLInterface.module.scss
+++ b/apps/frontend/src/app/GradTrak/BtLLInterface/BtLLInterface.module.scss
@@ -81,6 +81,14 @@
       position: relative;
       transition: all 0.2s ease;
 
+      // An expanded item's nested details would otherwise sit flush against the
+      // next sibling row. Radix's space scale (--space-*, from
+      // @radix-ui/themes/layout.css via ThemeProvider) is the app's spacing
+      // standard; --space-2 = 8px.
+      &.expanded {
+        padding-bottom: var(--space-2);
+      }
+
       .element {
         display: flex;
         justify-content: space-between;

--- a/apps/frontend/src/app/GradTrak/BtLLInterface/index.tsx
+++ b/apps/frontend/src/app/GradTrak/BtLLInterface/index.tsx
@@ -240,10 +240,10 @@ const renderRequirementDetails = (
       return (
         <div
           style={{
-            marginTop: "0.25rem",
+            marginTop: "var(--space-1)",
             display: "flex",
             flexDirection: "column",
-            gap: "0.25rem",
+            gap: "var(--space-1)",
           }}
         >
           {subRequirements.map((subReq, index) => {
@@ -416,7 +416,9 @@ function RequirementItem({
   return (
     <div
       key={itemKey}
-      className={styles.item}
+      className={classNames(styles.item, {
+        [styles.expanded]: isExpanded && hasDetails,
+      })}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
     >

--- a/apps/frontend/src/app/GradTrak/BtLLInterface/index.tsx
+++ b/apps/frontend/src/app/GradTrak/BtLLInterface/index.tsx
@@ -238,7 +238,14 @@ const renderRequirementDetails = (
       req.description?.data === "Domain Emphasis"
     ) {
       return (
-        <div style={{ marginTop: "0.25rem" }}>
+        <div
+          style={{
+            marginTop: "0.25rem",
+            display: "flex",
+            flexDirection: "column",
+            gap: "0.25rem",
+          }}
+        >
           {subRequirements.map((subReq, index) => {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             const flatIndex = (subReq as any).flatIndex;

--- a/apps/frontend/src/app/GradTrak/BtLLInterface/index.tsx
+++ b/apps/frontend/src/app/GradTrak/BtLLInterface/index.tsx
@@ -244,7 +244,8 @@ const renderRequirementDetails = (
             const flatIndex = (subReq as any).flatIndex;
             return (
               <div key={`sub-${index}`}>
-                {/* Render domain emphases as standard items without 'OR' connectors */}
+                {/* Render domain emphases collapsed by default — students complete one
+                    emphasis; showing all 16 expanded is overwhelming. */}
                 {renderRequirementItem(
                   subReq,
                   `de-sub-${index}`,
@@ -257,7 +258,8 @@ const renderRequirementDetails = (
                     ? (newOverride) => onToggleAny(flatIndex, newOverride)
                     : undefined,
                   allOverrides,
-                  onToggleAny
+                  onToggleAny,
+                  false
                 )}
               </div>
             );
@@ -322,6 +324,7 @@ function RequirementItem({
   onToggleManualOverride,
   allOverrides,
   onToggleAny,
+  defaultExpanded,
 }: {
   req: RequirementResult;
   key: string;
@@ -331,6 +334,7 @@ function RequirementItem({
   onToggleManualOverride?: (newOverride: boolean | null) => void;
   allOverrides?: (boolean | null)[];
   onToggleAny?: (index: number, newOverride: boolean | null) => void;
+  defaultExpanded?: boolean;
 }) {
   // requirementIndex is used by parent component when calling onToggleManualOverride
   void requirementIndex;
@@ -354,8 +358,11 @@ function RequirementItem({
     isManuallyNotMet,
   } = evaluateEffectiveMet(req, allOverrides);
 
-  // Default: expanded if incomplete, collapsed if complete
-  const [isExpanded, setIsExpanded] = useState(!isEffectivelyMet);
+  // Default: expanded if incomplete, collapsed if complete.
+  // defaultExpanded overrides this when provided (e.g. domain emphasis children).
+  const [isExpanded, setIsExpanded] = useState(
+    defaultExpanded ?? !isEffectivelyMet
+  );
   const [isHovered, setIsHovered] = useState(false);
 
   // Check if this requirement has details to show
@@ -470,7 +477,8 @@ const renderRequirementItem = (
   manualOverride?: boolean | null,
   onToggleManualOverride?: (newOverride: boolean | null) => void,
   allOverrides?: (boolean | null)[],
-  onToggleAny?: (index: number, newOverride: boolean | null) => void
+  onToggleAny?: (index: number, newOverride: boolean | null) => void,
+  defaultExpanded?: boolean
 ) => {
   return (
     <RequirementItem
@@ -482,6 +490,7 @@ const renderRequirementItem = (
       onToggleManualOverride={onToggleManualOverride}
       allOverrides={allOverrides}
       onToggleAny={onToggleAny}
+      defaultExpanded={defaultExpanded}
     />
   );
 };

--- a/apps/frontend/src/app/GradTrak/Dashboard/SidePanel/index.tsx
+++ b/apps/frontend/src/app/GradTrak/Dashboard/SidePanel/index.tsx
@@ -103,8 +103,7 @@ export default function SidePanel({
         <div className={styles.disclaimer}>
           <WarningCircle className={styles.icon} />
           <div className={styles.text}>
-            Future courses may not to be offered each semester. Remember to
-            check!
+            Future courses may not be offered each semester. Remember to check!
           </div>
         </div>
         <div className={styles.disclaimer}>


### PR DESCRIPTION
Students only complete one domain emphasis, so expanding every one by default buries the rest of the requirements. This collapses them, and fixes the spacing between the rows — using the spacing scale the app already loads rather than more hardcoded values.

Also fixes a typo in the side panel disclaimer.

**Before**
![before](https://raw.githubusercontent.com/asuc-octo/berkeleytime/69d0292ad53637e3d25c8bf7f253d38ddedb4746/screenshots/BEFORE-expanded.png)

**After**
![after](https://raw.githubusercontent.com/asuc-octo/berkeleytime/69d0292ad53637e3d25c8bf7f253d38ddedb4746/screenshots/AFTER-collapsed-spaced.png)

**With one emphasis expanded**
![after expanded](https://raw.githubusercontent.com/asuc-octo/berkeleytime/69d0292ad53637e3d25c8bf7f253d38ddedb4746/screenshots/AFTER-one-emphasis-expanded.png)