### PR TITLE
Fix curated-classes lockout by restoring the user staff check

### DIFF
--- a/apps/backend/src/modules/curated-classes/controller.ts
+++ b/apps/backend/src/modules/curated-classes/controller.ts
@@ -3,14 +3,13 @@ import {
   CuratedClassModel,
   IClassItem,
   ICourseItem,
+  UserType,
 } from "@repo/common/models";
 
 import {
   CreateCuratedClassInput,
   UpdateCuratedClassInput,
 } from "../../generated-types/graphql";
-import { RequestContext } from "../../types/request-context";
-import { requireStaffAuth } from "../analytics/helpers/staff-auth";
 import { getClass } from "../class/controller";
 import { formatClass } from "../class/formatter";
 import { ClassModule } from "../class/generated-types/module-types";
@@ -208,8 +207,11 @@ export const getCuratedClasses = async () => {
   );
 };
 
-export const getCuratedClass = async (context: RequestContext, id: string) => {
-  await requireStaffAuth(context);
+export const getCuratedClass = async (
+  context: { user?: UserType },
+  id: string
+) => {
+  if (!context.user?.staff) throw new Error("Unauthorized");
 
   const curatedClass = await CuratedClassModel.findOne({
     _id: id,
@@ -221,11 +223,11 @@ export const getCuratedClass = async (context: RequestContext, id: string) => {
 };
 
 export const updateCuratedClass = async (
-  context: RequestContext,
+  context: { user?: UserType },
   id: string,
   input: UpdateCuratedClassInput
 ) => {
-  await requireStaffAuth(context);
+  if (!context.user?.staff) throw new Error("Unauthorized");
 
   const curatedClass = await CuratedClassModel.findOneAndUpdate(
     {
@@ -240,10 +242,10 @@ export const updateCuratedClass = async (
 };
 
 export const deleteCuratedClass = async (
-  context: RequestContext,
+  context: { user?: UserType },
   id: string
 ) => {
-  await requireStaffAuth(context);
+  if (!context.user?.staff) throw new Error("Unauthorized");
 
   const curatedClass = await CuratedClassModel.findOneAndDelete({
     _id: id,
@@ -254,14 +256,14 @@ export const deleteCuratedClass = async (
 };
 
 export const createCuratedClass = async (
-  context: RequestContext,
+  context: { user?: UserType },
   input: CreateCuratedClassInput
 ) => {
-  await requireStaffAuth(context);
+  if (!context.user?.staff) throw new Error("Unauthorized");
 
   const curatedClass = await CuratedClassModel.create({
     ...input,
-    createdBy: context.user!._id,
+    createdBy: context.user._id,
     publishedAt: new Date(),
   });
 


### PR DESCRIPTION
## Problem

An AG user reported that the curated-classes list at `/curated-classes` renders fine, but clicking any post to edit shows **"Error loading data."**

#1167 swapped the authorization check in `curated-classes/controller.ts` from the `user.staff` flag to `requireStaffAuth`, the helper written for the analytics dashboard. These encode different permissions:

| | Source of truth |
|---|---|
| `user.staff` | boolean field on the user document |
| `requireStaffAuth` | a row in the `staff-members` collection |

The two have drifted. On production, one AG user has `staff: true` but no `staff-members` row, so `curatedClass`, `updateCuratedClass`, and `deleteCuratedClass` all reject them with `Only staff members can access analytics data`.

The list page still works because `getCuratedClasses` has no auth check at all, which is why this surfaced only on the edit page. The frontend collapses any GraphQL error into a generic message (`app/CuratedClass/index.tsx:177`), which is why the report was hard to act on.

## Fix

Restore the previous check in all four functions. This is an **exact revert** of the auth change to this file — `git diff` against `01b4b59af^` is empty. The persisted-operation boundary introduced by #1167 is untouched, and `requireStaffAuth` keeps its ten analytics call sites.

## Verification

`type-check`, `lint`, and `test` (8/8, including the persisted-operation suite) all pass.

Tested end to end against a local stack seeded with the affected account shape — `staff: true`, zero `staff-members` rows — querying the real `GetCuratedClass` persisted operation through the gateway with a real session:

| Account | With fix | Without fix |
|---|---|---|
| `staff: true`, no `staff-members` row | ✅ returns the record | ❌ `Only staff members can access analytics data` |
| `staff: false` | ❌ blocked | ❌ blocked |
| unauthenticated | ❌ blocked | ❌ blocked |

The middle column reproduces the reported production error exactly, so the test detects the bug rather than passing vacuously. Non-staff and anonymous access stay refused.

## Follow-up (not in this PR)

`deserializeUser` (`passport.ts:177`) returns the session object verbatim and never re-reads the user, so `req.user` is a snapshot taken at login. Two consequences:

1. **`staff` changes don't take effect until re-login.** With a 365-day TTL and `rolling: true`, revoking staff can take up to a year to apply. Note `requireStaffAuth` did a live DB read and so did *not* have this problem — this revert restores correct authorization but also restores the stale snapshot.
2. **Staff-gated pages are untestable locally.** The dev-login route stores only `{_id, email}` (`passport.ts:262`) while Google OAuth stores the full document (`passport.ts:219`), so `req.user.staff` is `undefined` in local dev for every user. This is plausibly why the regression shipped — the curated-classes edit page has never worked in local development.

Both are fixed by having `deserializeUser` read the user back, folding into the `lastSeenAt` write that already happens each request. That change **must** return a plain object — the gateway spreads `req.user` (`persistedOperationGateway.ts:180`), and spreading a hydrated Mongoose document yields `$__`/`_doc` rather than the fields, which would lock out every staff user the same silent way this bug did:

```ts
const fresh = await UserModel.findOneAndUpdate(
  { _id: user._id }, { lastSeenAt: new Date() }, { new: true }
).lean();   // .lean() is load-bearing, not stylistic
done(null, fresh);
```

Deliberately left out of this PR: it changes auth behavior for every logged-in user and deserves its own review. It's also the right home for a regression test, since a live deserialize makes staff state locally testable for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011faPRTWYhNSeC6NDQjxUWe
