### PR TITLE
Live-read the session user on deserialize

### DIFF
--- a/apps/backend/src/bootstrap/loaders/passport.ts
+++ b/apps/backend/src/bootstrap/loaders/passport.ts
@@ -176,13 +176,16 @@ export default async (app: Application, redis: RedisClientType) => {
   });
   passport.deserializeUser(async (user: { _id: string } | undefined, done) => {
     try {
-      if (user?._id) {
-        await UserModel.updateOne(
-          { _id: user._id },
-          { lastSeenAt: new Date() }
-        );
+      if (!user?._id) {
+        done(null, user);
+        return;
       }
-      done(null, user);
+      const fresh = await UserModel.findOneAndUpdate(
+        { _id: user._id },
+        { lastSeenAt: new Date() },
+        { new: true }
+      ).lean();
+      done(null, fresh ?? user);
     } catch (error) {
       done(error as Error);
     }


### PR DESCRIPTION
## Summary
- `passport.deserializeUser` replayed the login-time session snapshot verbatim, so DB changes to a user (e.g. flipping `staff` after #1177 reverted `getCuratedClass`/etc. to the `user.staff` check) didn't take effect until the user logged out and back in — up to 365 days (`AUTHENTICATED_SESSION_TTL`).
- Switched to `UserModel.findOneAndUpdate(...).lean()` so every request re-reads the current user doc instead of trusting the stale snapshot.
- `.lean()` matters: `persistedOperationGateway.ts` builds the GraphQL context by spreading `req.user` — spreading a hydrated Mongoose document loses all real fields (`user.staff` comes back `undefined`), while a `.lean()`/plain-object result spreads correctly.

## Test plan
- [x] `npm run type-check` passes
- [x] Verified end-to-end against the local Docker stack: seeded a user with `staff: false`, logged in via dev-login, confirmed `GetUser` returned `staff: false`; flipped `staff` to `true` directly in Mongo (no re-login); re-queried with the same session cookie and confirmed `staff: true` came back immediately — the exact `context.user.staff` field the curated-classes resolvers from #1177 depend on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FPzygAUKuCeBwSFCc1TgPw