### PR TITLE
Remove stray .claude lock file, gitignore .claude/

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"4582a968-a5d2-4dc1-8c79-2a3ca28b3ad5","pid":10550,"acquiredAt":1774240847330}

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ generated-typedefs/
 /blob-report/
 /playwright/.cache/
 /playwright/.auth/
+
+# Claude Code
+.claude/


### PR DESCRIPTION
## Summary
- Removes `.claude/scheduled_tasks.lock`, a runtime lock file (session id/pid/timestamp) that was accidentally committed months ago alongside an unrelated datapuller change.
- Adds `.claude/` to `.gitignore` so local Claude Code state doesn't get re-committed.

## Test plan
- N/A (removes an untracked runtime artifact, no code behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R4jXZQ7ZXZkXoVXtd99A4T