### PR TITLE
address ISP

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -5,8 +5,18 @@ BACKEND_PATH=/api
 GRAPHQL_PATH=/graphql
 NODE_ENV=development
 SEMANTIC_SEARCH_URL=http://semantic-search:8000
-MONGODB_URI=mongodb://mongodb:27017/bt?replicaSet=rs0
-REDIS_URI=redis://redis:6379
+# Generated locally by `node scripts/initialize-local-env.mjs`.
+DEV_BIND_ADDRESS=127.0.0.1
+MONGODB_IMAGE=mongodb/mongodb-atlas-local:8.0
+MONGODB_ROOT_USERNAME=bt_dev
+MONGODB_ROOT_PASSWORD=
+MONGODB_URI=
+REDIS_PASSWORD=
+REDIS_URI=
+MINIO_IMAGE=minio/minio:latest
+MINIO_MC_IMAGE=minio/mc:latest
+MINIO_ROOT_USER=bt_dev
+MINIO_ROOT_PASSWORD=
 BACKEND_URL=http://backend:8080
 TZ=America/Los_Angeles # for tslog
 
@@ -31,8 +41,8 @@ SESSION_SECRET=_
 
 S3_ENDPOINT=http://minio:9000
 S3_IMAGES_ACCESS_URL=http://localhost:9000/images
-S3_ACCESS_KEY_ID=root
-S3_SECRET_ACCESS_KEY=password
+S3_ACCESS_KEY_ID=bt_dev
+S3_SECRET_ACCESS_KEY=
 
 CLOUDFLARE_API_TOKEN=_
 CLOUDFLARE_ZONE_ID=_

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci-compose-security.yaml
+++ b/.github/workflows/ci-compose-security.yaml
@@ -1,0 +1,26 @@
+name: "CI: Compose Security"
+
+on:
+  pull_request:
+    paths:
+      - "docker-compose.yml"
+      - ".env.template"
+      - "scripts/initialize-local-env.mjs"
+      - "scripts/check-compose-network-security.mjs"
+      - ".github/workflows/ci-compose-security.yaml"
+
+jobs:
+  compose-security:
+    name: Check local-service exposure
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22.12.0"
+      - name: Generate ephemeral local credentials
+        run: |
+          cp .env.template .env
+          node scripts/initialize-local-env.mjs
+      - name: Check Compose port bindings and database authentication
+        run: node scripts/check-compose-network-security.mjs

--- a/.github/workflows/ci-playwright.yaml
+++ b/.github/workflows/ci-playwright.yaml
@@ -18,6 +18,8 @@ on:
       - "tests/**"
       - "infra/app/**"
       - "docker-compose.yml"
+      - ".env.template"
+      - "scripts/initialize-local-env.mjs"
       - "nginx.conf"
       - "playwright.config.ts"
 
@@ -45,7 +47,9 @@ jobs:
         run: npx playwright install --with-deps chromium
 
       - name: Prepare test environment
-        run: cp .env.template .env
+        run: |
+          cp .env.template .env
+          node scripts/initialize-local-env.mjs
 
       - name: Run persisted-operation boundary tests
         env:

--- a/apps/docs/src/getting-started/bootstrap-local.sh
+++ b/apps/docs/src/getting-started/bootstrap-local.sh
@@ -105,6 +105,11 @@ ensure_env_file() {
   log "Created .env from .env.template"
 }
 
+initialize_local_secrets() {
+  step "Generating local service credentials"
+  node scripts/initialize-local-env.mjs
+}
+
 setup_repo_deps() {
   step "Installing repo dependencies"
 
@@ -150,8 +155,10 @@ seed_database() {
   [[ -n "$mongo_container_id" ]] || die "MongoDB container not found. Is Docker Compose running?"
 
   docker cp "./$backup_file" "${mongo_container_id}:/tmp/prod-backup.gz"
-  docker exec "$mongo_container_id" mongorestore --drop --gzip --archive=/tmp/prod-backup.gz
-  docker exec "$mongo_container_id" mongosh bt --eval 'const r = db.users.findOneAndUpdate({ email: "dev@berkeleytime.local" }, { $setOnInsert: { googleId: "dev-fake-public-backup", email: "dev@berkeleytime.local", name: "Dev User", staff: false, lastSeenAt: new Date() } }, { upsert: true, returnDocument: "after" }); print("Dev user id: " + r._id); print("Login URL: http://localhost:3000/api/dev/login?userId=" + r._id + "&redirect_uri=/");'
+  local mongo_uri
+  mongo_uri="$(grep '^MONGODB_URI=' .env | cut -d= -f2-)"
+  docker exec "$mongo_container_id" mongorestore "$mongo_uri" --drop --gzip --archive=/tmp/prod-backup.gz
+  docker exec "$mongo_container_id" mongosh "$mongo_uri" --eval 'const r = db.users.findOneAndUpdate({ email: "dev@berkeleytime.local" }, { $setOnInsert: { googleId: "dev-fake-public-backup", email: "dev@berkeleytime.local", name: "Dev User", staff: false, lastSeenAt: new Date() } }, { upsert: true, returnDocument: "after" }); print("Dev user id: " + r._id); print("Login URL: http://localhost:3000/api/dev/login?userId=" + r._id + "&redirect_uri=/");'
   log "MongoDB restore complete."
 }
 
@@ -178,6 +185,7 @@ main() {
 
   setup_node
   ensure_env_file
+  initialize_local_secrets
   setup_repo_deps
 
   if [[ "$NO_DOCKER" == "true" ]]; then

--- a/apps/docs/src/getting-started/local-development.md
+++ b/apps/docs/src/getting-started/local-development.md
@@ -51,8 +51,9 @@ git switch main
 # Continue installation of dependencies.
 pre-commit install
 
-# Create .env from template file
+# Create .env from template file and generate local database credentials
 cp .env.template .env
+node scripts/initialize-local-env.mjs
 
 # Setup local code editor intellisense.
 npm install
@@ -66,6 +67,17 @@ docker compose up -d
 ```
 
 The Berkeleytime application should now be running locally at `http://localhost:3000`! Make sure that each page (catalog, grades, etc.) is working as expected.
+
+### Applying the database-security upgrade to an existing checkout
+
+MongoDB creates its initial authenticated user only when its local data volume is first initialized. If you already have a Berkeleytime MongoDB volume, export any local-only work you need, then recreate the local services and reseed the redacted public backup:
+
+```sh
+docker compose down --volumes
+bash apps/docs/src/getting-started/bootstrap-local.sh
+```
+
+This removes local Docker volumes only; it does not affect production or staging data.
 
 ## Common Commands
 
@@ -111,7 +123,7 @@ docker compose --profile ag --profile staff up -d
 ```
 
 ## Ports
-`docker compose up` will automatically setup certain services on your localhost ports. By default, `DEV_PORT_PREFIX` is set to `30`, which means services will be available on ports starting with `30XX`. You can adjust this by setting the `DEV_PORT_PREFIX` environment variable if you need to run multiple instances of the repository in parallel (e.g., for git worktree setups).
+`docker compose up` publishes local development services only on `127.0.0.1`; they are not reachable from your Wi-Fi or other network interfaces. By default, `DEV_PORT_PREFIX` is set to `30`, which means services will be available on ports starting with `30XX`. You can adjust this by setting the `DEV_PORT_PREFIX` environment variable if you need to run multiple instances of the repository in parallel (e.g., for git worktree setups). Do not change `DEV_BIND_ADDRESS` unless you have separately configured network controls and service authentication.
 
 The following ports are used by default (`DEV_PORT_PREFIX=30`):
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
     networks:
       - bt
     ports:
-      - "${DEV_PORT_PREFIX:-30}10:8000"
+      - "${DEV_BIND_ADDRESS:-127.0.0.1}:${DEV_PORT_PREFIX:-30}10:8000"
     restart: always
     volumes:
       - ./apps/semantic-search/app:/app/app
@@ -48,7 +48,7 @@ services:
       - SEMANTIC_SEARCH_YEAR=2026
       - SEMANTIC_SEARCH_SEMESTER=Spring
       - BACKEND_URL=http://backend:5001
-      - REDIS_URI=redis://redis:6379
+      - REDIS_URI=redis://:${REDIS_PASSWORD:?Set REDIS_PASSWORD in .env}@redis:6379
   frontend:
     build:
       context: .
@@ -133,7 +133,8 @@ services:
       - mongodb-db:/data/db
       - mongodb-configdb:/data/configdb
   mongodb:
-    image: mongodb/mongodb-atlas-local:8.0
+    image: ${MONGODB_IMAGE:?Set MONGODB_IMAGE in .env}
+    pull_policy: always
     hostname: rs0
     depends_on:
       mongodb-preflight:
@@ -141,9 +142,12 @@ services:
     networks:
       - bt
     ports:
-      - "${DEV_PORT_PREFIX:-30}08:27017"
+      - "${DEV_BIND_ADDRESS:-127.0.0.1}:${DEV_PORT_PREFIX:-30}08:27017"
+    environment:
+      MONGODB_INITDB_ROOT_USERNAME: ${MONGODB_ROOT_USERNAME:?Set MONGODB_ROOT_USERNAME in .env}
+      MONGODB_INITDB_ROOT_PASSWORD: ${MONGODB_ROOT_PASSWORD:?Set MONGODB_ROOT_PASSWORD in .env}
     healthcheck:
-      test: '/usr/bin/mongosh --port 27017 --quiet --eval "db.runCommand({ ping: 1 }).ok"'
+      test: '/usr/bin/mongosh --host localhost --port 27017 --username "$$MONGODB_INITDB_ROOT_USERNAME" --password "$$MONGODB_INITDB_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "db.runCommand({ ping: 1 }).ok"'
       interval: 5s
       timeout: 10s
       start_period: 15s
@@ -153,12 +157,15 @@ services:
       - mongodb-configdb:/data/configdb
       - ./infra/mongo/migrations:/migrations
   mongodb-init:
-    image: mongodb/mongodb-atlas-local:8.0
+    image: ${MONGODB_IMAGE:?Set MONGODB_IMAGE in .env}
+    pull_policy: always
     depends_on:
       mongodb:
         condition: service_healthy
     networks:
       - bt
+    environment:
+      MONGODB_INIT_URI: mongodb://${MONGODB_ROOT_USERNAME:?Set MONGODB_ROOT_USERNAME in .env}:${MONGODB_ROOT_PASSWORD:?Set MONGODB_ROOT_PASSWORD in .env}@mongodb:27017/bt?authSource=admin&replicaSet=rs0
     restart: "no"
     entrypoint:
       - /bin/sh
@@ -166,7 +173,7 @@ services:
       - -ec
       - |
         attempts=0
-        until mongosh "mongodb://mongodb:27017/bt" /scripts/01-create-search-indexes.js; do
+        until mongosh "$$MONGODB_INIT_URI" /scripts/01-create-search-indexes.js; do
           attempts=$$((attempts + 1))
           if [ "$$attempts" -ge 30 ]; then
             echo "mongodb-init failed after $$attempts attempts."
@@ -187,16 +194,19 @@ services:
     networks:
       - bt
     ports:
-      - "${DEV_PORT_PREFIX:-30}00:8080"
-      - "${DEV_PORT_PREFIX:-30}01:8081"
-      - "${DEV_PORT_PREFIX:-30}02:8082"
+      - "${DEV_BIND_ADDRESS:-127.0.0.1}:${DEV_PORT_PREFIX:-30}00:8080"
+      - "${DEV_BIND_ADDRESS:-127.0.0.1}:${DEV_PORT_PREFIX:-30}01:8081"
+      - "${DEV_BIND_ADDRESS:-127.0.0.1}:${DEV_PORT_PREFIX:-30}02:8082"
     restart: always
     volumes:
       - ./nginx.conf:/etc/nginx/conf.d/default.conf
   redis:
     image: redis/redis-stack-server:7.2.0-v14
     ports:
-      - "${DEV_PORT_PREFIX:-30}04:6379"
+      - "${DEV_BIND_ADDRESS:-127.0.0.1}:${DEV_PORT_PREFIX:-30}04:6379"
+    environment:
+      REDIS_ARGS: "--requirepass ${REDIS_PASSWORD:?Set REDIS_PASSWORD in .env}"
+      REDIS_PASSWORD: ${REDIS_PASSWORD:?Set REDIS_PASSWORD in .env}
     networks:
       - bt
     restart: always
@@ -207,6 +217,8 @@ services:
         condition: service_started
     networks:
       - bt
+    environment:
+      REDIS_PASSWORD: ${REDIS_PASSWORD:?Set REDIS_PASSWORD in .env}
     restart: "no"
     entrypoint:
       - /bin/sh
@@ -214,7 +226,7 @@ services:
       - -ec
       - |
         attempts=0
-        until [ "$$(redis-cli -h redis ping)" = "PONG" ]; do
+        until [ "$$(redis-cli --no-auth-warning -h redis -a "$$REDIS_PASSWORD" ping)" = "PONG" ]; do
           attempts=$$((attempts + 1))
           if [ "$$attempts" -ge 30 ]; then
             echo "redis-preflight failed waiting for redis."
@@ -223,7 +235,7 @@ services:
           sleep 1
         done
 
-        redis-cli -h redis FLUSHALL
+        redis-cli --no-auth-warning -h redis -a "$$REDIS_PASSWORD" FLUSHALL
         echo "Flushed redis cache on startup."
   storybook:
     profiles:
@@ -233,7 +245,7 @@ services:
       dockerfile: ./apps/storybook/Dockerfile
       target: storybook-dev
     ports:
-      - "${DEV_PORT_PREFIX:-30}05:6006"
+      - "${DEV_BIND_ADDRESS:-127.0.0.1}:${DEV_PORT_PREFIX:-30}05:6006"
     networks:
       - bt
     restart: always
@@ -248,7 +260,7 @@ services:
       dockerfile: ./apps/docs/Dockerfile
       target: docs-dev
     ports:
-      - "${DEV_PORT_PREFIX:-30}03:3000"
+      - "${DEV_BIND_ADDRESS:-127.0.0.1}:${DEV_PORT_PREFIX:-30}03:3000"
     networks:
       - bt
     restart: always
@@ -257,29 +269,32 @@ services:
       
   # if using staff photos in dev, use --profile dev
   minio:
-    image: 'minio/minio:latest'
+    image: ${MINIO_IMAGE:?Set MINIO_IMAGE in .env}
     profiles:
       - dev
     ports:
-      - "${DEV_PORT_PREFIX:-30}06:9000"
-      - "${DEV_PORT_PREFIX:-30}07:9090"
+      - "${DEV_BIND_ADDRESS:-127.0.0.1}:${DEV_PORT_PREFIX:-30}06:9000"
+      - "${DEV_BIND_ADDRESS:-127.0.0.1}:${DEV_PORT_PREFIX:-30}07:9090"
     environment:
-      MINIO_ROOT_USER: 'root'
-      MINIO_ROOT_PASSWORD: 'password'
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:?Set MINIO_ROOT_USER in .env}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:?Set MINIO_ROOT_PASSWORD in .env}
     networks:
       - bt
     volumes:
       - 'minio:/data/minio'
     command: minio server /data/minio --console-address ":9090"
   createbuckets:
-    image: minio/mc
+    image: ${MINIO_MC_IMAGE:?Set MINIO_MC_IMAGE in .env}
     profiles:
       - dev
     depends_on:
       - minio
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:?Set MINIO_ROOT_USER in .env}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:?Set MINIO_ROOT_PASSWORD in .env}
     entrypoint: >
       /bin/sh -c "
-      /usr/bin/mc alias set myminio http://localhost:9000 root password;
+      /usr/bin/mc alias set myminio http://minio:9000 "$$MINIO_ROOT_USER" "$$MINIO_ROOT_PASSWORD";
       /usr/bin/mc mb myminio/images; 
       /usr/bin/mc anonymous set public myminio/images;
       exit 0;

--- a/scripts/check-compose-network-security.mjs
+++ b/scripts/check-compose-network-security.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+
+const envPath = process.argv[2];
+const composeArgs = ["compose"];
+if (envPath) composeArgs.push("--env-file", envPath);
+composeArgs.push("config", "--format", "json");
+
+const config = JSON.parse(
+  execFileSync("docker", composeArgs, {
+    encoding: "utf8",
+  })
+);
+
+const failures = [];
+for (const [service, definition] of Object.entries(config.services ?? {})) {
+  for (const port of definition.ports ?? []) {
+    if (port.host_ip !== "127.0.0.1") {
+      failures.push(`${service} publishes ${port.published} without a loopback host IP`);
+    }
+  }
+}
+
+const redisArgs = config.services?.redis?.environment?.REDIS_ARGS ?? "";
+if (!redisArgs.includes("--requirepass")) {
+  failures.push("redis does not require authentication");
+}
+
+const mongoEnvironment = config.services?.mongodb?.environment ?? {};
+if (!mongoEnvironment.MONGODB_INITDB_ROOT_USERNAME || !mongoEnvironment.MONGODB_INITDB_ROOT_PASSWORD) {
+  failures.push("mongodb does not configure root authentication");
+}
+
+if (failures.length) {
+  throw new Error(`Compose security checks failed:\n- ${failures.join("\n- ")}`);
+}
+
+console.log("Compose network and database authentication checks passed.");

--- a/scripts/initialize-local-env.mjs
+++ b/scripts/initialize-local-env.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+
+import { randomBytes } from "node:crypto";
+import { chmodSync, readFileSync, writeFileSync } from "node:fs";
+
+const envPath = process.argv[2] ?? ".env";
+const contentState = { value: readFileSync(envPath, "utf8") };
+const values = new Map(
+  contentState.value
+    .split(/\r?\n/)
+    .flatMap((line) => {
+      const match = line.match(/^([A-Z0-9_]+)=(.*)$/);
+      return match ? [[match[1], match[2]]] : [];
+    })
+);
+
+const generated = [];
+const randomSecret = () => randomBytes(32).toString("base64url");
+const missing = (name) => !values.get(name) || values.get(name).startsWith("<");
+
+function set(name, value) {
+  const line = `${name}=${value}`;
+  const pattern = new RegExp(`^${name}=.*$`, "m");
+
+  if (pattern.test(contentState.value)) {
+    contentState.value = contentState.value.replace(pattern, line);
+  } else {
+    contentState.value = `${contentState.value.replace(/\n*$/, "")}\n${line}\n`;
+  }
+  values.set(name, value);
+}
+
+if (missing("MONGODB_ROOT_PASSWORD")) {
+  set("MONGODB_ROOT_PASSWORD", randomSecret());
+  generated.push("MONGODB_ROOT_PASSWORD");
+}
+if (missing("REDIS_PASSWORD")) {
+  set("REDIS_PASSWORD", randomSecret());
+  generated.push("REDIS_PASSWORD");
+}
+if (missing("MINIO_ROOT_PASSWORD")) {
+  set("MINIO_ROOT_PASSWORD", randomSecret());
+  generated.push("MINIO_ROOT_PASSWORD");
+}
+
+const mongoUser = values.get("MONGODB_ROOT_USERNAME") || "bt_dev";
+const mongoPassword = values.get("MONGODB_ROOT_PASSWORD");
+const redisPassword = values.get("REDIS_PASSWORD");
+const minioUser = values.get("MINIO_ROOT_USER") || "bt_dev";
+const minioPassword = values.get("MINIO_ROOT_PASSWORD");
+
+const legacyMongoUri = "mongodb://mongodb:27017/bt?replicaSet=rs0";
+const legacyRedisUri = "redis://redis:6379";
+if (missing("MONGODB_URI") || values.get("MONGODB_URI") === legacyMongoUri) {
+  set(
+    "MONGODB_URI",
+    `mongodb://${mongoUser}:${mongoPassword}@mongodb:27017/bt?authSource=admin&replicaSet=rs0`
+  );
+}
+if (missing("REDIS_URI") || values.get("REDIS_URI") === legacyRedisUri) {
+  set("REDIS_URI", `redis://:${redisPassword}@redis:6379`);
+}
+if (missing("S3_SECRET_ACCESS_KEY") || values.get("S3_SECRET_ACCESS_KEY") === "password") {
+  set("S3_SECRET_ACCESS_KEY", minioPassword);
+}
+if (missing("S3_ACCESS_KEY_ID") || values.get("S3_ACCESS_KEY_ID") === "root") {
+  set("S3_ACCESS_KEY_ID", minioUser);
+}
+
+writeFileSync(envPath, contentState.value);
+chmodSync(envPath, 0o600);
+
+if (generated.length) {
+  console.log(`Generated local credentials: ${generated.join(", ")}`);
+} else {
+  console.log("Local service credentials already configured.");
+}


### PR DESCRIPTION
- docker binds to port 127.0.0.1 instead of 0.0.0.0
- redis and mongo now require generated credentials (run `node scripts/initialize-local-env.mjs` to generate)
- CI enforces these security requirements

In order to enable auth for Mongo, we need to remove the existing volume. The bootstrap-local script now includes generating the redis/mongo credentials.
```
docker compose down --volumes
docker compose pull
bash apps/docs/src/getting-started/bootstrap-local.sh
```
