### PR TITLE
Use design tokens for UserRatingSummary spacing and font weights

### DIFF
--- a/apps/frontend/src/components/Class/Ratings/UserRatingSummary/UserRatingSummary.module.scss
+++ b/apps/frontend/src/components/Class/Ratings/UserRatingSummary/UserRatingSummary.module.scss
@@ -34,7 +34,7 @@
       display: flex;
       flex-direction: column;
       align-items: flex-start;
-      gap: 4px;
+      gap: var(--space-1);
       flex: 1 0 0;
     }
     h3,
@@ -48,7 +48,7 @@
       font-family: Inter;
       font-size: var(--font-sizes-2, 14px);
       font-style: normal;
-      font-weight: 600;
+      font-weight: var(--font-semibold);
       line-height: 20px; /* 142.857% */
       letter-spacing: -0.1px;
       word-break: break-word;
@@ -62,7 +62,7 @@
       font-family: Inter;
       font-size: var(--font-sizes-1, 12px);
       font-style: normal;
-      font-weight: var(--font-weight-regular, 400);
+      font-weight: var(--font-normal);
       line-height: 16px; /* 133.333% */
     }
     h5 {
@@ -73,7 +73,7 @@
       font-family: Inter;
       font-size: var(--font-sizes-2, 14px);
       font-style: normal;
-      font-weight: 400;
+      font-weight: var(--font-normal);
       line-height: 20px; /* 142.857% */
       letter-spacing: -0.1px;
       word-break: break-word;
@@ -86,7 +86,7 @@
       font-feature-settings: "liga" off;
       font-family: Inter;
       font-size: var(--font-sizes-2, 14px);
-      font-weight: 400;
+      font-weight: var(--font-normal);
       line-height: 20px;
       letter-spacing: -0.1px;
       word-break: break-word;
@@ -102,7 +102,7 @@
         display: inline;
         background: none;
         border: none;
-        padding: 0 0 0 4px;
+        padding: 0 0 0 var(--space-1);
         color: var(--blue-badge);
         font-family: Inter;
         font-size: var(--font-sizes-2, 14px);
@@ -136,7 +136,7 @@
         display: flex;
         flex-direction: column;
         align-items: flex-start;
-        gap: 4px;
+        gap: var(--space-1);
         flex: 1 0 0;
         padding-right: var(--space-4, 16px);
 
@@ -149,7 +149,7 @@
         color: var(--secondary-color);
         font-family: Inter;
         font-size: var(--font-sizes-2, 14px);
-        font-weight: 500;
+        font-weight: var(--font-medium);
         line-height: 20px;
         letter-spacing: -0.1px;
       }
@@ -158,7 +158,7 @@
         color: var(--paragraph-color);
         font-family: Inter;
         font-size: var(--font-sizes-2, 14px);
-        font-weight: 400;
+        font-weight: var(--font-normal);
         line-height: 20px;
       }
     }
@@ -200,7 +200,7 @@
   font-family: Inter;
   font-size: var(--font-sizes-2, 14px);
   font-style: normal;
-  font-weight: 500;
+  font-weight: var(--font-medium);
   line-height: 20px; /* 142.857% */
   letter-spacing: -0.1px;
 }


### PR DESCRIPTION
Replace hard-coded 4px spacing and font-weight literals with --space-1 and --font-* tokens, and fix the undefined --font-weight-regular reference.