### PR TITLE
Use design tokens for ClassCard spacing

### DIFF
--- a/apps/frontend/src/components/ClassCard/ClassCard.module.scss
+++ b/apps/frontend/src/components/ClassCard/ClassCard.module.scss
@@ -5,7 +5,7 @@
 .headingWithPrefix {
   display: inline-flex;
   align-items: baseline;
-  gap: 8px;
+  gap: var(--space-2);
   min-width: 0;
 }
 
@@ -25,7 +25,7 @@
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .titleDescription {
@@ -37,7 +37,7 @@
   flex: 0 0 auto;
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .infoRow {
@@ -45,8 +45,8 @@
   align-items: center;
   justify-content: flex-start;
   flex-wrap: wrap;
-  column-gap: 12px;
-  row-gap: 8px;
+  column-gap: var(--space-3);
+  row-gap: var(--space-2);
 }
 
 .reservedSeating {
@@ -56,7 +56,7 @@
   margin: 0;
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--space-1);
   cursor: pointer;
 }
 
@@ -82,7 +82,7 @@
   margin: 0;
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--space-1);
 }
 
 .ratingsIcon {


### PR DESCRIPTION
Replace hard-coded 4/8/12px gaps with --space-1/2/3 while leaving icon sizes unchanged.