### PR TITLE
Use design tokens for ClassBrowser Filters spacing

### DIFF
--- a/apps/frontend/src/components/ClassBrowser/Filters/Filters.module.scss
+++ b/apps/frontend/src/components/ClassBrowser/Filters/Filters.module.scss
@@ -15,7 +15,7 @@
     width: 384px;
 
     .body {
-      padding-top: 12px;
+      padding-top: var(--space-3);
     }
   }
 
@@ -24,15 +24,15 @@
     width: 100%;
 
     .body {
-      padding-top: 12px;
+      padding-top: var(--space-3);
     }
   }
 
   .body {
     display: flex;
     flex-direction: column;
-    padding: 24px;
-    gap: 16px;
+    padding: var(--space-5);
+    gap: var(--space-4);
 
     .closeFiltersButton {
       width: 100%;
@@ -90,12 +90,12 @@
       font-size: var(--text-14);
       line-height: 20px;
       color: var(--heading-color);
-      margin-bottom: 8px;
+      margin-bottom: var(--space-2);
     }
 
     .sortControls {
       display: flex;
-      gap: 8px;
+      gap: var(--space-2);
       align-items: stretch;
 
       > :first-child {
@@ -114,8 +114,8 @@
 
     .timeRangeInputs {
       display: flex;
-      gap: 16px;
-      margin-top: 12px;
+      gap: var(--space-4);
+      margin-top: var(--space-3);
     }
 
     .timeInputGroup {
@@ -127,7 +127,7 @@
     .timeLabel {
       font-size: var(--text-12);
       color: var(--paragraph-color);
-      margin-bottom: 4px;
+      margin-bottom: var(--space-1);
     }
 
     .timeInput {
@@ -171,7 +171,7 @@
 
   :global([role="tab"]) {
     border-radius: 4px 4px 0 0;
-    padding: 6px 8px;
+    padding: 6px var(--space-2);
     min-height: 28px;
     background: transparent;
     box-shadow: none;


### PR DESCRIPTION
Replace hard-coded on-scale spacing with --space-* tokens while leaving off-scale sizes and radii unchanged.