### PR TITLE
Backfill user majors from GradTrak plans

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -8,6 +8,7 @@
     "test": "tsx --test \"src/**/*.test.ts\"",
     "lint": "eslint src/",
     "generate": "node scripts/prepare-typedefs.js && graphql-codegen --config codegen.ts",
+    "migrate:user-majors": "tsx src/scripts/backfill-user-majors.ts",
     "type-check": "tsc --noEmit --incremental false"
   },
   "devDependencies": {

--- a/apps/backend/src/scripts/backfill-user-majors.ts
+++ b/apps/backend/src/scripts/backfill-user-majors.ts
@@ -1,0 +1,195 @@
+/**
+ * One-time migration script: seeds empty user majors and minors from the
+ * user's GradTrak plan. Safe to re-run — existing non-empty user fields are
+ * never overwritten.
+ *
+ * Usage:
+ *   DRY_RUN=1 npm run migrate:user-majors
+ *   npm run migrate:user-majors
+ */
+import mongoose from "mongoose";
+
+import { VALID_MAJORS, VALID_MINORS } from "@repo/common/lib/degreePrograms";
+import { PlanModel, UserModel } from "@repo/common/models";
+
+const BATCH_SIZE = 500;
+const DRY_RUN = process.env.DRY_RUN === "1";
+
+type Plan = {
+  userEmail: string;
+  majors: string[];
+  minors: string[];
+};
+
+type User = {
+  _id: mongoose.Types.ObjectId;
+  email: string;
+  majors?: string[] | null;
+  minors?: string[] | null;
+};
+
+type Summary = {
+  plansScanned: number;
+  usersUpdated: number;
+  majorsBackfilled: number;
+  minorsBackfilled: number;
+  skippedNoUser: number;
+  skippedAlreadySet: number;
+  skippedInvalidValue: number;
+};
+
+const isEmptyOrAbsent = (value: string[] | null | undefined) =>
+  value === undefined ||
+  value === null ||
+  (Array.isArray(value) && value.length === 0);
+
+const emptyFieldFilter = (field: "majors" | "minors") => ({
+  $or: [
+    { [field]: { $exists: false } },
+    { [field]: null },
+    { [field]: { $size: 0 } },
+  ],
+});
+
+async function processBatch(plans: Plan[], summary: Summary) {
+  const users = await UserModel.find({
+    email: { $in: plans.map((plan) => plan.userEmail) },
+  })
+    .select({ email: 1, majors: 1, minors: 1 })
+    .lean<User[]>();
+  const usersByEmail = new Map(users.map((user) => [user.email, user]));
+
+  for (const plan of plans) {
+    summary.plansScanned += 1;
+
+    const invalidMajors = plan.majors.filter(
+      (major) => !VALID_MAJORS.has(major)
+    );
+    const invalidMinors = plan.minors.filter(
+      (minor) => !VALID_MINORS.has(minor)
+    );
+    if (invalidMajors.length > 0 || invalidMinors.length > 0) {
+      summary.skippedInvalidValue += 1;
+      console.log(
+        `Skipping ${plan.userEmail}: invalid majors [${invalidMajors.join(", ")}], invalid minors [${invalidMinors.join(", ")}]`
+      );
+      continue;
+    }
+
+    const user = usersByEmail.get(plan.userEmail);
+    if (!user) {
+      summary.skippedNoUser += 1;
+      continue;
+    }
+
+    const update: { majors?: string[]; minors?: string[] } = {};
+    const emptyFields = [];
+
+    if (plan.majors.length > 0 && isEmptyOrAbsent(user.majors)) {
+      update.majors = plan.majors;
+      emptyFields.push(emptyFieldFilter("majors"));
+    }
+    if (plan.minors.length > 0 && isEmptyOrAbsent(user.minors)) {
+      update.minors = plan.minors;
+      emptyFields.push(emptyFieldFilter("minors"));
+    }
+
+    if (Object.keys(update).length === 0) {
+      summary.skippedAlreadySet += 1;
+      continue;
+    }
+
+    const changes = Object.entries(update)
+      .map(([field, values]) => `${field}=[${values.join(", ")}]`)
+      .join(" ");
+
+    if (DRY_RUN) {
+      console.log(`Would update ${plan.userEmail}: ${changes}`);
+      summary.usersUpdated += 1;
+      summary.majorsBackfilled += update.majors ? 1 : 0;
+      summary.minorsBackfilled += update.minors ? 1 : 0;
+      continue;
+    }
+
+    const result = await UserModel.updateOne(
+      { $and: [{ _id: user._id }, ...emptyFields] },
+      { $set: update }
+    );
+    if (result.modifiedCount === 1) {
+      console.log(`Updated ${plan.userEmail}: ${changes}`);
+      summary.usersUpdated += 1;
+      summary.majorsBackfilled += update.majors ? 1 : 0;
+      summary.minorsBackfilled += update.minors ? 1 : 0;
+    } else {
+      summary.skippedAlreadySet += 1;
+    }
+  }
+}
+
+async function migrate() {
+  const uri = process.env.MONGODB_URI;
+  if (!uri) throw new Error("MONGODB_URI env var is required");
+
+  await mongoose.connect(uri);
+  console.log("Connected to MongoDB");
+  console.log(DRY_RUN ? "DRY RUN — no users will be changed" : "LIVE RUN");
+
+  try {
+    const filter = {
+      $or: [
+        { "majors.0": { $exists: true } },
+        { "minors.0": { $exists: true } },
+      ],
+    };
+    const total = await PlanModel.countDocuments(filter);
+    console.log(`Found ${total} plans with majors or minors`);
+
+    const summary: Summary = {
+      plansScanned: 0,
+      usersUpdated: 0,
+      majorsBackfilled: 0,
+      minorsBackfilled: 0,
+      skippedNoUser: 0,
+      skippedAlreadySet: 0,
+      skippedInvalidValue: 0,
+    };
+    const cursor = PlanModel.find(filter)
+      .select({ userEmail: 1, majors: 1, minors: 1 })
+      .lean<Plan>()
+      .cursor();
+    const batch: Plan[] = [];
+
+    for await (const plan of cursor) {
+      batch.push(plan);
+      if (batch.length >= BATCH_SIZE) {
+        await processBatch(batch, summary);
+        batch.length = 0;
+        console.log(`Processed ${summary.plansScanned} of ${total} plans`);
+      }
+    }
+
+    await processBatch(batch, summary);
+
+    console.log("\nSummary");
+    console.log(`  Plans scanned: ${summary.plansScanned}`);
+    console.log(
+      `  Users ${DRY_RUN ? "that would be updated" : "updated"}: ${summary.usersUpdated}`
+    );
+    console.log(
+      `  Majors ${DRY_RUN ? "that would be backfilled" : "backfilled"}: ${summary.majorsBackfilled}`
+    );
+    console.log(
+      `  Minors ${DRY_RUN ? "that would be backfilled" : "backfilled"}: ${summary.minorsBackfilled}`
+    );
+    console.log(`  Skipped — no user: ${summary.skippedNoUser}`);
+    console.log(`  Skipped — already set: ${summary.skippedAlreadySet}`);
+    console.log(`  Skipped — invalid value: ${summary.skippedInvalidValue}`);
+  } finally {
+    await mongoose.disconnect();
+  }
+}
+
+migrate().catch((error) => {
+  console.error("Migration failed:", error);
+  process.exit(1);
+});

--- a/packages/common/src/models/plan.ts
+++ b/packages/common/src/models/plan.ts
@@ -182,6 +182,9 @@ export const planSchema = new Schema(
   { timestamps: true }
 );
 
+// for enforcing one plan per user
+planSchema.index({ userEmail: 1 }, { unique: true });
+
 export type SelectedCourseType = InferSchemaType<typeof selectedCourseSchema> &
   Document;
 export const SelectedCourseModel = mongoose.model<SelectedCourseType>(


### PR DESCRIPTION
## Summary

- add an idempotent migration that backfills empty `user.majors` and
  `user.minors` fields from each user's GradTrak plan
- validate all migrated values against the canonical vocabulary introduced by
  PR #1187
- add a unique index on `plans.userEmail` to enforce one plan per user at the
  database layer

This PR is stacked on #1187 (`ritam/major-vocabulary-plumbing`); review and merge
that PR first.

## Production data findings

The initial read-only audit found:

- 2,802 plans and 47,013 users
- 2,685 plans with non-empty majors and 792 with non-empty minors
- no plan major/minor values outside the canonical vocabulary
- five degree-bearing plans without a matching user
- 11,745 users with existing majors, traced to the April 2025 PostgreSQL-to-MongoDB
  user migration; these values are intentionally never overwritten

The audit also found 18 duplicate `plan.userEmail` groups containing 43
superseded plans. Per Ritam's decision, the older plans were archived intact in
`plans_duplicate_archive_pr2_20260909` and removed, retaining the newest plan for
each user. Production now has zero duplicate groups.

The `plans.userEmail_1` unique index has already been built and verified manually
in production. No additional manual index build is required after deployment;
the schema declaration keeps the invariant in code and applies it to other
environments.

## Migration behavior

The migration processes plans in batches of 500 and:

- supports `DRY_RUN=1`, logging every proposed change without writing
- copies a field only when the corresponding user field is empty, absent, or `null`
- skips plans without users instead of failing the run
- skips and reports non-canonical values
- uses conditional writes so concurrent profile updates cannot be overwritten
- reports plans scanned, users updated, major/minor fields backfilled, and every
  skip category

It is safe to rerun. After a successful live run, migrated users fall into the
already-set category.

Latest production dry-run snapshot (2026-09-09):

- 2,662 plans scanned
- 2,319 users would be updated
- 2,161 major fields would be backfilled (4.59% of 47,090 users)
- 783 minor fields would be backfilled
- five plans skipped without a user
- 338 plans skipped because the relevant user fields were already set
- zero plans skipped for invalid values

The live backfill has intentionally not been run. It will be executed immediately
before the profile major/minor editor is enabled.

## Usage

```bash
# Preview
DRY_RUN=1 npm run migrate:user-majors

# Apply
npm run migrate:user-majors
```

## Verification

- `npm run type-check --workspace=apps/backend`
- `npm run lint --workspace=apps/backend`
- `npx tsc -p packages/common/tsconfig.json --noEmit`
- ESLint on the changed common-package files
- production dry run with fully reconciled counters
- production unique index and zero-duplicate verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QNN5LA8L23gjK9vEsKHAVV
