### PR TITLE
Fix semantic search index rebuild authorization and eviction safety

### DIFF
--- a/apps/backend/src/bootstrap/loaders/express.ts
+++ b/apps/backend/src/bootstrap/loaders/express.ts
@@ -90,7 +90,7 @@ export default async (
   trackingRoutes(app, redis);
 
   // load semantic search routes
-  app.use("/semantic-search", semanticSearchRoutes);
+  app.use("/semantic-search", semanticSearchRoutes(redis));
 
   // load staff routes
   staffRoutes(app);

--- a/apps/backend/src/modules/semantic-search/routes.ts
+++ b/apps/backend/src/modules/semantic-search/routes.ts
@@ -1,9 +1,10 @@
 import { type Response, Router } from "express";
+import type { RedisClientType } from "redis";
 
 import { config } from "../../../../../packages/common/src/utils/config";
 import { searchCourses } from "./controller";
+import { createRefreshRateLimit, requireStaffRefreshAccess } from "./security";
 
-const router = Router();
 const baseUrl = config.semanticSearch.url.replace(/\/$/, "");
 
 async function forward(
@@ -30,43 +31,59 @@ async function forward(
   }
 }
 
-router.get("/health", async (_req, res) => {
-  await forward(`${baseUrl}/health`, { method: "GET" }, res);
-});
+export default function semanticSearchRoutes(redis: RedisClientType) {
+  const router = Router();
 
-router.post("/refresh", async (req, res) => {
-  const body = req.body ?? {};
-  await forward(
-    `${baseUrl}/refresh`,
-    {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify(body),
-    },
-    res
+  router.get("/health", async (_req, res) => {
+    await forward(`${baseUrl}/health`, { method: "GET" }, res);
+  });
+
+  router.post(
+    "/refresh",
+    requireStaffRefreshAccess,
+    createRefreshRateLimit(redis),
+    async (req, res) => {
+      const body = req.body ?? {};
+      await forward(
+        `${baseUrl}/refresh`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(body),
+        },
+        res
+      );
+    }
   );
-});
 
-// Lightweight endpoint: returns only course identifiers for frontend filtering
-router.get("/courses", searchCourses);
+  // Lightweight endpoint: returns only course identifiers for frontend filtering
+  router.get("/courses", searchCourses);
 
-// Full proxy endpoint (kept for backwards compatibility)
-router.post("/search", async (req, res) => {
-  const body = req.body ?? {};
-  if (!body.query || !String(body.query).trim()) {
-    res.status(400).json({ error: "query is required" });
-    return;
-  }
+  // Full proxy endpoint (kept for backwards compatibility)
+  router.post("/search", async (req, res) => {
+    const body = req.body ?? {};
+    if (!body.query || !String(body.query).trim()) {
+      res.status(400).json({ error: "query is required" });
+      return;
+    }
 
-  await forward(
-    `${baseUrl}/search`,
-    {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify(body),
-    },
-    res
-  );
-});
+    const searchRequest = {
+      query: body.query,
+      threshold: body.threshold,
+      year: body.year,
+      semester: body.semester,
+    };
 
-export default router;
+    await forward(
+      `${baseUrl}/search`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(searchRequest),
+      },
+      res
+    );
+  });
+
+  return router;
+}

--- a/apps/backend/src/modules/semantic-search/security.test.ts
+++ b/apps/backend/src/modules/semantic-search/security.test.ts
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { createRefreshRateLimit, requireStaffRefreshAccess } from "./security";
+
+type ResponseSnapshot = {
+  body?: unknown;
+  headers: Record<string, string>;
+  status?: number;
+};
+
+function responseStub(snapshot: ResponseSnapshot) {
+  return {
+    json(body: unknown) {
+      snapshot.body = body;
+      return this;
+    },
+    setHeader(name: string, value: string) {
+      snapshot.headers[name.toLowerCase()] = value;
+      return this;
+    },
+    status(status: number) {
+      snapshot.status = status;
+      return this;
+    },
+  };
+}
+
+test("semantic refresh rejects anonymous callers", async () => {
+  const snapshot: ResponseSnapshot = { headers: {} };
+  let continued = false;
+
+  await requireStaffRefreshAccess(
+    { isAuthenticated: () => false } as never,
+    responseStub(snapshot) as never,
+    () => {
+      continued = true;
+    }
+  );
+
+  assert.equal(continued, false);
+  assert.equal(snapshot.status, 401);
+  assert.deepEqual(snapshot.body, { error: "Authentication required" });
+});
+
+test("semantic refresh rejects authenticated non-staff callers", async () => {
+  const snapshot: ResponseSnapshot = { headers: {} };
+  let continued = false;
+
+  await requireStaffRefreshAccess(
+    { isAuthenticated: () => true, user: { staff: false } } as never,
+    responseStub(snapshot) as never,
+    () => {
+      continued = true;
+    }
+  );
+
+  assert.equal(continued, false);
+  assert.equal(snapshot.status, 403);
+  assert.deepEqual(snapshot.body, { error: "Staff access required" });
+});
+
+test("semantic refresh allows authenticated staff callers", async () => {
+  const snapshot: ResponseSnapshot = { headers: {} };
+  let continued = false;
+
+  await requireStaffRefreshAccess(
+    { isAuthenticated: () => true, user: { staff: true } } as never,
+    responseStub(snapshot) as never,
+    () => {
+      continued = true;
+    }
+  );
+
+  assert.equal(continued, true);
+  assert.equal(snapshot.status, undefined);
+});
+
+test("semantic refresh rate limiter allows the first build request", async () => {
+  const redis = {
+    set: async () => "OK",
+    ttl: async () => {
+      throw new Error("ttl should not be read for an acquired refresh slot");
+    },
+  };
+  const snapshot: ResponseSnapshot = { headers: {} };
+  let continued = false;
+
+  await createRefreshRateLimit(redis as never)(
+    {} as never,
+    responseStub(snapshot) as never,
+    () => {
+      continued = true;
+    }
+  );
+
+  assert.equal(continued, true);
+  assert.equal(snapshot.status, undefined);
+});
+
+test("semantic refresh rate limiter rejects a second build request", async () => {
+  const redis = {
+    set: async () => null,
+    ttl: async () => 47,
+  };
+  const snapshot: ResponseSnapshot = { headers: {} };
+  let continued = false;
+
+  await createRefreshRateLimit(redis as never)(
+    {} as never,
+    responseStub(snapshot) as never,
+    () => {
+      continued = true;
+    }
+  );
+
+  assert.equal(continued, false);
+  assert.equal(snapshot.status, 429);
+  assert.equal(snapshot.headers["retry-after"], "47");
+  assert.deepEqual(snapshot.body, {
+    error: "A semantic search refresh was requested recently",
+  });
+});

--- a/apps/backend/src/modules/semantic-search/security.ts
+++ b/apps/backend/src/modules/semantic-search/security.ts
@@ -1,0 +1,47 @@
+import type { RequestHandler } from "express";
+import type { RedisClientType } from "redis";
+
+const REFRESH_RATE_LIMIT_KEY = "semantic-search:refresh-rate-limit";
+const REFRESH_RATE_LIMIT_SECONDS = 5 * 60;
+
+export const requireStaffRefreshAccess: RequestHandler = (req, res, next) => {
+  if (!req.isAuthenticated()) {
+    res.status(401).json({ error: "Authentication required" });
+    return;
+  }
+
+  const isStaff = (req.user as { staff?: boolean } | undefined)?.staff === true;
+  if (!isStaff) {
+    res.status(403).json({ error: "Staff access required" });
+    return;
+  }
+
+  next();
+};
+
+export const createRefreshRateLimit = (
+  redis: Pick<RedisClientType, "set" | "ttl">
+): RequestHandler => {
+  return async (_req, res, next) => {
+    try {
+      const acquired = await redis.set(REFRESH_RATE_LIMIT_KEY, "1", {
+        NX: true,
+        EX: REFRESH_RATE_LIMIT_SECONDS,
+      });
+
+      if (acquired) {
+        next();
+        return;
+      }
+
+      const ttl = await redis.ttl(REFRESH_RATE_LIMIT_KEY);
+      res.setHeader("Retry-After", String(Math.max(ttl, 1)));
+      res.status(429).json({
+        error: "A semantic search refresh was requested recently",
+      });
+    } catch (error) {
+      console.error("Semantic search refresh rate limit error:", error);
+      res.status(503).json({ error: "Unable to authorize semantic refresh" });
+    }
+  };
+};

--- a/apps/semantic-search/app/engine.py
+++ b/apps/semantic-search/app/engine.py
@@ -368,11 +368,8 @@ class SemanticSearchEngine:
                 self._indices[key] = loaded
             return loaded
 
-        # Index not ready — start a background build if nothing is already running,
-        # then return an error immediately so the request doesn't hang.
-        self.refresh_async(year, canonical_semester, allowed)
         raise RuntimeError(
-            f"Index for {canonical_semester} {year} is still being built. Please try again in a moment."
+            f"Index for {canonical_semester} {year} is not available."
         )
 
     def _key(self, year: int, semester: str, allowed_subjects: Optional[List[str]]) -> str:
@@ -505,13 +502,23 @@ class SemanticSearchEngine:
                 if cursor == 0:
                     break
 
-            # Sort newest first
-            all_meta.sort(
-                key=lambda m: (m.get("year", 0), SEMESTER_ORDER.get(m.get("semester", ""), 0)),
+            # Retention is based on distinct academic terms, not index variants.
+            # Otherwise filtered indexes for one term can crowd the production
+            # unfiltered index out of the fixed-size metadata list.
+            terms = {
+                (meta.get("year", 0), meta.get("semester", ""))
+                for meta in all_meta
+            }
+            newest_terms = sorted(
+                terms,
+                key=lambda term: (term[0], SEMESTER_ORDER.get(term[1], 0)),
                 reverse=True,
-            )
+            )[:max_terms]
+            keep_terms = set(newest_terms)
 
-            for meta in all_meta[max_terms:]:
+            for meta in all_meta:
+                if (meta.get("year", 0), meta.get("semester", "")) in keep_terms:
+                    continue
                 try:
                     index_name = self._get_index_name(meta["year"], meta["semester"], meta.get("allowed_subjects"))
                     schema = self._build_schema(index_name)

--- a/apps/semantic-search/tests/test_engine_security.py
+++ b/apps/semantic-search/tests/test_engine_security.py
@@ -1,0 +1,166 @@
+import json
+import sys
+import threading
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import Mock
+
+
+semantic_search_root = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(semantic_search_root))
+
+
+redis_module = types.ModuleType("redis")
+redis_module.from_url = Mock()
+sys.modules.setdefault("redis", redis_module)
+
+redisvl_module = types.ModuleType("redisvl")
+redisvl_index_module = types.ModuleType("redisvl.index")
+redisvl_query_module = types.ModuleType("redisvl.query")
+redisvl_redis_module = types.ModuleType("redisvl.redis")
+redisvl_utils_module = types.ModuleType("redisvl.redis.utils")
+redisvl_index_module.SearchIndex = object
+redisvl_query_module.VectorQuery = object
+redisvl_utils_module.array_to_buffer = Mock()
+sys.modules.setdefault("redisvl", redisvl_module)
+sys.modules.setdefault("redisvl.index", redisvl_index_module)
+sys.modules.setdefault("redisvl.query", redisvl_query_module)
+sys.modules.setdefault("redisvl.redis", redisvl_redis_module)
+sys.modules.setdefault("redisvl.redis.utils", redisvl_utils_module)
+
+sentence_transformers_module = types.ModuleType("sentence_transformers")
+sentence_transformers_module.SentenceTransformer = object
+sys.modules.setdefault("sentence_transformers", sentence_transformers_module)
+
+from app import engine as engine_module
+
+
+class FakeRedis:
+    def __init__(self, metadata):
+        self.metadata = metadata
+        self.deleted = []
+
+    def scan(self, _cursor, match=None, count=None):
+        return 0, list(self.metadata)
+
+    def get(self, key):
+        value = self.metadata.get(key)
+        return json.dumps(value) if value is not None else None
+
+    def delete(self, key):
+        self.deleted.append(key)
+
+
+class FakeSearchIndex:
+    deleted_names = []
+
+    def __init__(self, name):
+        self.name = name
+
+    @classmethod
+    def from_dict(cls, schema, redis_url=None):
+        return cls(schema["index"]["name"])
+
+    def exists(self):
+        return True
+
+    def delete(self, drop=False):
+        self.deleted_names.append(self.name)
+
+
+def bare_engine():
+    engine = engine_module.SemanticSearchEngine.__new__(
+        engine_module.SemanticSearchEngine
+    )
+    engine._indices = {}
+    engine._lock = threading.RLock()
+    engine._embedding_dims = 3
+    engine.default_allowed_subjects = None
+    return engine
+
+
+class SemanticSearchSecurityTests(unittest.TestCase):
+    def setUp(self):
+        self.original_search_index = engine_module.SearchIndex
+        engine_module.SearchIndex = FakeSearchIndex
+        FakeSearchIndex.deleted_names = []
+
+    def tearDown(self):
+        engine_module.SearchIndex = self.original_search_index
+
+    def test_missing_index_does_not_start_a_background_build(self):
+        engine = bare_engine()
+        engine._load_redis_index = Mock(return_value=None)
+        engine.refresh_async = Mock()
+
+        with self.assertRaisesRegex(RuntimeError, "not available"):
+            engine._get_or_build_index(2026, "Fall", ["COMPSCI"])
+
+        engine.refresh_async.assert_not_called()
+
+    def test_filtered_indexes_cannot_crowd_out_production_term_indexes(self):
+        metadata = {
+            "semantic_search:meta:filtered-cs": {
+                "year": 2026,
+                "semester": "Fall",
+                "allowed_subjects": ["COMPSCI"],
+            },
+            "semantic_search:meta:filtered-data": {
+                "year": 2026,
+                "semester": "Fall",
+                "allowed_subjects": ["DATA"],
+            },
+            "semantic_search:meta:production-current": {
+                "year": 2026,
+                "semester": "Fall",
+                "allowed_subjects": None,
+            },
+            "semantic_search:meta:production-previous": {
+                "year": 2026,
+                "semester": "Spring",
+                "allowed_subjects": None,
+            },
+        }
+        engine = bare_engine()
+        engine._redis = FakeRedis(metadata)
+
+        engine._evict_old_indexes(max_terms=2)
+
+        self.assertEqual(engine._redis.deleted, [])
+        self.assertEqual(FakeSearchIndex.deleted_names, [])
+
+    def test_eviction_still_removes_indexes_older_than_retained_terms(self):
+        metadata = {
+            "semantic_search:meta:current": {
+                "year": 2026,
+                "semester": "Fall",
+                "allowed_subjects": None,
+            },
+            "semantic_search:meta:previous": {
+                "year": 2026,
+                "semester": "Spring",
+                "allowed_subjects": None,
+            },
+            "semantic_search:meta:old-filtered": {
+                "year": 2025,
+                "semester": "Fall",
+                "allowed_subjects": ["COMPSCI"],
+            },
+        }
+        engine = bare_engine()
+        engine._redis = FakeRedis(metadata)
+
+        engine._evict_old_indexes(max_terms=2)
+
+        self.assertEqual(
+            engine._redis.deleted, ["semantic_search:meta:old-filtered"]
+        )
+        self.assertEqual(
+            FakeSearchIndex.deleted_names,
+            ["semantic_search:2025:Fall:COMPSCI"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Addresses [BER-5](https://linear.app/berkeleytime/issue/BER-5/anyone-can-rebuild-or-delete-course-search-indexes-without-logging-in)

### Summary
- Restrict semantic search index refreshes to authenticated staff
- Add a five-minute Redis-backed refresh rate limit
- Prevent searches for missing indexes from triggering background builds
- Preserve production indexes by evicting based on distinct academic terms
- Add tests for authorization, throttling, rebuild prevention, and eviction